### PR TITLE
feat: add identifierCodingKey, fallbackType parameter default value

### DIFF
--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
@@ -17,15 +17,16 @@ import Foundation
 
  - Parameters:
    - identifierCodingKey: The key name in the JSON used to determine the concrete type.
+      The default value for this property is `"type"`.
    - matchingTypes: An array of polymorphic types that this strategy will handle.
    - fallbackType: Optional type to use when no matching type is found. If nil, decoding will fail
-                   when no matching type is found.
+                   when no matching type is found. The default value for this property is `nil`.
  */
 @attached(peer, names: suffixed(CodableStrategy))
 public macro PolymorphicCodableStrategyProviding(
-  identifierCodingKey: String,
+  identifierCodingKey: String = "type",
   matchingTypes: [PolymorphicDecodableType.Type],
-  fallbackType: PolymorphicDecodableType.Type?
+  fallbackType: PolymorphicDecodableType.Type? = nil
 ) = #externalMacro(
   module: "KarrotCodableKitMacros",
   type: "PolymorphicCodableStrategyProvidingMacro"


### PR DESCRIPTION
## Background (Required)
<!-- Describe the background for this work. -->

- Referencing the polymorphism implementation in [Kotlin serializers](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#custom-subclass-serial-name), I've added "type" as the default value for identifierCodingKey. This is a commonly used naming convention in the industry, making it suitable as a default value.

## Changes
<!-- List the changes explicitly. -->
- add identifierCodingKey, fallbackType parameter default value
- update document commnets

## Testing Methods
<!-- Describe how to test the changes. -->
- unit test

## Review Notes
<!-- Include any information that would help with the review. -->
- Additionally, I've set the default value of fallbackType to nil. This makes throwing a decoding error the default behavior when an unmatched type is encountered during decoding.
