### PR TITLE
IOS-582 fix: UnnestedPolymorphicCodable compiler errors when empty structs and Swift keywords

### DIFF
--- a/Sources/KarrotCodableKitMacros/Extensions/String+Trimming.swift
+++ b/Sources/KarrotCodableKitMacros/Extensions/String+Trimming.swift
@@ -1,0 +1,14 @@
+//
+//  String+removeBackticks.swift
+//  KarrotCodableKit
+//
+//  Created by elon on 6/11/25.
+//
+
+import Foundation
+
+extension String {
+  var trimmingBackticks: String {
+    trimmingCharacters(in: ["`"])
+  }
+}

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
@@ -34,21 +34,22 @@ enum CodingKeysSyntaxFactory {
   static func makeCodingKeysCases(from declaration: some DeclGroupSyntax) -> [String] {
     extractStoredPropertyDeclarations(from: declaration)
       .map { propertyDeclaration in
+        let propertyName = propertyDeclaration.propertyName.trimmingBackticks
         if
           let codableKeyAttribute = codableKeyAttribute(from: propertyDeclaration.variableDecl.attributes),
           let customKeyValue = customKeyValue(from: codableKeyAttribute.as(AttributeSyntax.self))
         {
-          return "case \(propertyDeclaration.propertyName) = \(customKeyValue)"
+          return "case `\(propertyName)` = \(customKeyValue)"
         }
 
         if needsToSnakeCaseCodingKeyValue(by: declaration) {
           let snakeCaseKey = propertyDeclaration.propertyName.toSnakeCase
           if propertyDeclaration.propertyName != snakeCaseKey {
-            return "case \(propertyDeclaration.propertyName) = \"\(snakeCaseKey)\""
+            return "case `\(propertyName)` = \"\(snakeCaseKey)\""
           }
         }
 
-        return "case \(propertyDeclaration.propertyName)"
+        return "case `\(propertyName)`"
       }
   }
 

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
@@ -20,6 +20,10 @@ enum CodingKeysSyntaxFactory {
     guard !declaration.is(EnumDeclSyntax.self) else { throw CodableKitError.cannotApplyToEnum }
 
     let cases = makeCodingKeysCases(from: declaration)
+    guard !cases.isEmpty else {
+      return "private enum CodingKeys: CodingKey {}"
+    }
+
     return """
       private enum CodingKeys: String, CodingKey {
         \(raw: cases.joined(separator: "\n"))

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicEnumCodableFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicEnumCodableFactory.swift
@@ -20,7 +20,7 @@ enum PolymorphicEnumCodableFactory {
   static func makePolymorphicMetaCodingKey(with identifierCodingKey: String) -> String {
     """
     enum PolymorphicMetaCodingKey: CodingKey {
-      case \(identifierCodingKey)
+      case `\(identifierCodingKey.trimmingBackticks)`
     }
     """
   }

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicSyntaxFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicSyntaxFactory.swift
@@ -13,7 +13,7 @@ enum UnnestedPolymorphicSyntaxFactory {
   static func makeTopLevelCodingKeysSyntax(nestedKey: String) -> DeclSyntax {
     """
     private enum CodingKeys: String, CodingKey {
-      case \(raw: nestedKey)
+      case `\(raw: nestedKey.trimmingBackticks)`
     }
     """
   }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
@@ -14,11 +14,10 @@ import KarrotCodableKit
   matchingTypes: [
     TitleViewItem.self,
     ImageViewItem.self,
+    EmptyViewItem.self,
   ]
 )
-protocol ViewItem {
-  var id: String { get }
-}
+protocol ViewItem {}
 
 // MARK: - Codable
 
@@ -36,6 +35,13 @@ struct TitleViewItem: ViewItem {
   let id: String
   let itemTitle: String?
 }
+
+@UnnestedPolymorphicCodable(
+  identifier: "EMPTY_VIEW_ITEM",
+  forKey: "data",
+  codingKeyStyle: .snakeCase
+)
+struct EmptyViewItem: ViewItem {}
 
 // MARK: - Decodable
 

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
@@ -52,10 +52,11 @@ struct DummyDecodingFeedResponse: Decodable {
 
 @UnnestedPolymorphicDecodable(
   identifier: "IMAGE_VIEW_ITEM",
-  forKey: "info",
+  forKey: "default",
   codingKeyStyle: .snakeCase
 )
 struct ImageViewItem: ViewItem {
   let id: String
   let imageURL: URL
+  let `class`: String
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicCodableTests.swift
@@ -22,6 +22,13 @@ struct UnnestedPolymorphicCodableTests {
             "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
             "item_title": "Hello, world!"
           }
+        },
+        {
+          "type": "EMPTY_VIEW_ITEM",
+          "data": {}
+        },
+        {
+          "type": "EMPTY_VIEW_ITEM"
         }
       ]
     }
@@ -31,12 +38,14 @@ struct UnnestedPolymorphicCodableTests {
     let result = try JSONDecoder().decode(DummyFeedResponse.self, from: Data(jsonData.utf8))
 
     // then
-    #expect(result.items.count == 1)
+    #expect(result.items.count == 3)
 
-    let item = try #require(result.items.first)
-    let titleViewItem = try #require(item as? TitleViewItem)
+    let titleViewItem = try #require(result.items[0] as? TitleViewItem)
     #expect(titleViewItem.id == "1e243b34-b8a6-41c8-b08f-cba8d014021f")
     #expect(titleViewItem.itemTitle == "Hello, world!")
+
+    _ = try #require(result.items[1] as? EmptyViewItem)
+    _ = try #require(result.items[2] as? EmptyViewItem)
   }
 
   @Test func encodingUnnestedPolymorphicCodable() async throws  {
@@ -46,7 +55,8 @@ struct UnnestedPolymorphicCodableTests {
         TitleViewItem(
           id: "1e243b34-b8a6-41c8-b08f-cba8d014021f",
           itemTitle: "Hello, world!"
-        )
+        ),
+        EmptyViewItem(),
       ]
     )
 
@@ -65,6 +75,12 @@ struct UnnestedPolymorphicCodableTests {
             "item_title" : "Hello, world!"
           },
           "type" : "TITLE_VIEW_ITEM"
+        },
+        {
+          "data" : {
+
+          },
+          "type" : "EMPTY_VIEW_ITEM"
         }
       ]
     }
@@ -73,3 +89,4 @@ struct UnnestedPolymorphicCodableTests {
     #expect(jsonString == expectResult)
   }
 }
+

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicDecodableTests.swift
@@ -19,9 +19,10 @@ struct UnnestedPolymorphicDecodableTests {
       "items": [
         {
           "type": "IMAGE_VIEW_ITEM",
-          "info": {
+          "default": {
             "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
-            "image_url": "https://karrotmarket.com"
+            "image_url": "https://karrotmarket.com",
+            "class": "1-A"
           }
         }
       ]
@@ -38,5 +39,6 @@ struct UnnestedPolymorphicDecodableTests {
     let imageViewItem = try #require(item as? ImageViewItem)
     #expect(imageViewItem.id == "1e243b34-b8a6-41c8-b08f-cba8d014021f")
     #expect(imageViewItem.imageURL.absoluteString == "https://karrotmarket.com")
+    #expect(imageViewItem.`class` == "1-A")
   }
 }

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomCodableMacroTests.swift
@@ -40,8 +40,8 @@ final class CustomCodableMacroTests: XCTestCase {
           let userProfileURL: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileURL = "user_profile_url"
+            case `name`
+            case `userProfileURL` = "user_profile_url"
           }
         }
 
@@ -72,8 +72,8 @@ final class CustomCodableMacroTests: XCTestCase {
           let userProfileUrl: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileUrl
+            case `name`
+            case `userProfileUrl`
           }
         }
 
@@ -113,14 +113,14 @@ extension CustomCodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
 
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty = "nested_struct_property"
+            case `nestedStructProperty` = "nested_struct_property"
           }
         }
 
@@ -159,7 +159,7 @@ extension CustomCodableMacroTests {
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty
+            case `nestedStructProperty`
           }
         }
 
@@ -168,7 +168,7 @@ extension CustomCodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
         }
@@ -214,9 +214,9 @@ extension CustomCodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 
@@ -257,9 +257,9 @@ extension CustomCodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomDecodableMacroTests.swift
@@ -40,8 +40,8 @@ final class CustomDecodableMacroTests: XCTestCase {
           let userProfileURL: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileURL = "user_profile_url"
+            case `name`
+            case `userProfileURL` = "user_profile_url"
           }
         }
 
@@ -72,8 +72,8 @@ final class CustomDecodableMacroTests: XCTestCase {
           let userProfileUrl: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileUrl
+            case `name`
+            case `userProfileUrl`
           }
         }
 
@@ -113,14 +113,14 @@ extension CustomDecodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
 
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty = "nested_struct_property"
+            case `nestedStructProperty` = "nested_struct_property"
           }
         }
 
@@ -159,7 +159,7 @@ extension CustomDecodableMacroTests {
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty
+            case `nestedStructProperty`
           }
         }
 
@@ -168,7 +168,7 @@ extension CustomDecodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
         }
@@ -214,9 +214,9 @@ extension CustomDecodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 
@@ -257,9 +257,9 @@ extension CustomDecodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomEncodableMacroTests.swift
@@ -40,8 +40,8 @@ final class CustomEncodableMacroTests: XCTestCase {
           let userProfileURL: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileURL = "user_profile_url"
+            case `name`
+            case `userProfileURL` = "user_profile_url"
           }
         }
 
@@ -72,8 +72,8 @@ final class CustomEncodableMacroTests: XCTestCase {
           let userProfileUrl: String
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userProfileUrl
+            case `name`
+            case `userProfileUrl`
           }
         }
 
@@ -113,14 +113,14 @@ extension CustomEncodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
 
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty = "nested_struct_property"
+            case `nestedStructProperty` = "nested_struct_property"
           }
         }
 
@@ -159,7 +159,7 @@ extension CustomEncodableMacroTests {
           let nestedStructProperty: NestedStruct
 
           private enum CodingKeys: String, CodingKey {
-            case nestedStructProperty
+            case `nestedStructProperty`
           }
         }
 
@@ -168,7 +168,7 @@ extension CustomEncodableMacroTests {
             let propertyWithSameName: Bool
 
             private enum CodingKeys: String, CodingKey {
-              case propertyWithSameName = "property_with_same_name"
+              case `propertyWithSameName` = "property_with_same_name"
             }
           }
         }
@@ -214,9 +214,9 @@ extension CustomEncodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 
@@ -257,9 +257,9 @@ extension CustomEncodableMacroTests {
           func randomFunction() {}
 
           private enum CodingKeys: String, CodingKey {
-            case name
-            case userAge = "user_age"
-            case userProfileURL = "userProfileUrl"
+            case `name`
+            case `userAge` = "user_age"
+            case `userProfileURL` = "userProfileUrl"
           }
         }
 

--- a/Tests/KarrotCodableMacrosTests/Extenstions/TrimmingBackticksTests.swift
+++ b/Tests/KarrotCodableMacrosTests/Extenstions/TrimmingBackticksTests.swift
@@ -1,0 +1,31 @@
+//
+//  TrimmingBackticksTests.swift
+//  KarrotCodableKit
+//
+//  Created by elon on 6/11/25.
+//
+
+import Testing
+
+@testable import KarrotCodableKitMacros
+
+struct TrimmingBackticksTests {
+  @Test("Trimming backticks", arguments: [
+    ("``", ""),
+    ("```", ""),
+    ("`class`", "class"),
+    ("`func`", "func"),
+    ("`var`", "var"),
+    ("`let`", "let"),
+    ("`if`", "if"),
+    ("`else`", "else"),
+    ("`return`", "return"),
+    ("`for`", "for"),
+    ("`in`", "in"),
+    ("`while`", "while"),
+    ("`do`", "do"),
+  ])
+  func trimmingBackticks(testValues: (given: String, then: String)) async throws {
+    #expect(testValues.given.trimmingBackticks == testValues.then)
+  }
+}

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableMacroTests.swift
@@ -48,10 +48,10 @@ final class PolymorphicCodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle = "notice_title"
-            case description
-            case key
+            case `type`
+            case `noticeTitle` = "notice_title"
+            case `description`
+            case `key`
           }
         }
 
@@ -89,10 +89,10 @@ final class PolymorphicCodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle
-            case description
-            case key
+            case `type`
+            case `noticeTitle`
+            case `description`
+            case `key`
           }
         }
         """,

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicDeodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicDeodableMacroTests.swift
@@ -48,10 +48,10 @@ final class PolymorphicDecodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle = "notice_title"
-            case description
-            case key
+            case `type`
+            case `noticeTitle` = "notice_title"
+            case `description`
+            case `key`
           }
         }
 
@@ -92,10 +92,10 @@ final class PolymorphicDecodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle
-            case description
-            case key
+            case `type`
+            case `noticeTitle`
+            case `description`
+            case `key`
           }
         }
         """,

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicEncodableMacroTests.swift
@@ -48,10 +48,10 @@ final class PolymorphicEncodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle = "notice_title"
-            case description
-            case key
+            case `type`
+            case `noticeTitle` = "notice_title"
+            case `description`
+            case `key`
           }
         }
 
@@ -92,10 +92,10 @@ final class PolymorphicEncodableMacroTests: XCTestCase {
           let key: String
 
           private enum CodingKeys: String, CodingKey {
-            case type
-            case noticeTitle
-            case description
-            case key
+            case `type`
+            case `noticeTitle`
+            case `description`
+            case `key`
           }
         }
         """,

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
@@ -43,7 +43,7 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
 
         extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {
@@ -103,7 +103,7 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
 
         extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {
@@ -302,7 +302,7 @@ extension PolymorphicEnumCodableMacroTests {
 
         extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
@@ -43,7 +43,7 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
 
         extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {
@@ -92,7 +92,7 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
 
         extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {
@@ -280,7 +280,7 @@ extension PolymorphicEnumDecodableMacroTests {
 
         extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
-            case type
+            case `type`
           }
 
           public init(from decoder: any Decoder) throws {

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
@@ -150,4 +150,55 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
     throw XCTSkip("macros are only supported when running tests for the host platform")
     #endif
   }
+
+  func testUnnestedPolymorphicCodableMacroWithoutProperties() throws {
+    #if canImport(KarrotCodableKitMacros)
+    assertMacroExpansion(
+      """
+      @UnnestedPolymorphicCodable(
+        identifier: "TITLE_VIEW_ITEM",
+        forKey: "some_data",
+        codingKeyStyle: .snakeCase
+      )
+      struct TitleViewItem: ViewItem {
+
+      }
+      """,
+      expandedSource: """
+        struct TitleViewItem: ViewItem {
+
+          private enum CodingKeys: String, CodingKey {
+            case some_data
+          }
+
+          private enum NestedDataCodingKeys: CodingKey {
+          }
+
+        }
+
+        extension TitleViewItem: PolymorphicCodableType {
+          static var polymorphicIdentifier: String {
+            "TITLE_VIEW_ITEM"
+          }
+
+          init(from decoder: any Decoder) throws {
+
+          }
+
+          func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            _ = container.nestedContainer(
+              keyedBy: NestedDataCodingKeys.self,
+              forKey: CodingKeys.some_data
+            )
+          }
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2)
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
 }

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
@@ -41,12 +41,12 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
           let title: String?
 
           private enum CodingKeys: String, CodingKey {
-            case data
+            case `data`
           }
 
           private enum NestedDataCodingKeys: String, CodingKey {
-            case id
-            case title
+            case `id`
+            case `title`
           }
         }
 
@@ -106,12 +106,12 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
           let itemTitle: String?
 
           private enum CodingKeys: String, CodingKey {
-            case data
+            case `data`
           }
 
           private enum NestedDataCodingKeys: String, CodingKey {
-            case id
-            case itemTitle = "item_title"
+            case `id`
+            case `itemTitle` = "item_title"
           }
         }
 
@@ -168,7 +168,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         struct TitleViewItem: ViewItem {
 
           private enum CodingKeys: String, CodingKey {
-            case some_data
+            case `some_data`
           }
 
           private enum NestedDataCodingKeys: CodingKey {
@@ -191,6 +191,75 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
               keyedBy: NestedDataCodingKeys.self,
               forKey: CodingKeys.some_data
             )
+          }
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2)
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
+
+  func testUnnestedPolymorphicCodableMacroWithBacktickedProperties() throws {
+    #if canImport(KarrotCodableKitMacros)
+    assertMacroExpansion(
+      """
+      @UnnestedPolymorphicCodable(
+        identifier: "SPECIAL_VIEW_ITEM",
+        forKey: "data"
+      )
+      struct SpecialViewItem: ViewItem {
+        let id: String
+        let `class`: String
+        let `private`: String?
+      }
+      """,
+      expandedSource: """
+        struct SpecialViewItem: ViewItem {
+          let id: String
+          let `class`: String
+          let `private`: String?
+
+          private enum CodingKeys: String, CodingKey {
+            case `data`
+          }
+
+          private enum NestedDataCodingKeys: String, CodingKey {
+            case `id`
+            case `class`
+            case `private`
+          }
+        }
+
+        extension SpecialViewItem: PolymorphicCodableType {
+          static var polymorphicIdentifier: String {
+            "SPECIAL_VIEW_ITEM"
+          }
+
+          init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let dataContainer = try container.nestedContainer(
+              keyedBy: NestedDataCodingKeys.self,
+              forKey: CodingKeys.data
+            )
+
+            self.id = try dataContainer.decode(String.self, forKey: NestedDataCodingKeys.id)
+            self.`class` = try dataContainer.decode(String.self, forKey: NestedDataCodingKeys.`class`)
+            self.`private` = try dataContainer.decode(String?.self, forKey: NestedDataCodingKeys.`private`)
+          }
+
+          func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            var dataContainer = container.nestedContainer(
+              keyedBy: NestedDataCodingKeys.self,
+              forKey: CodingKeys.data
+            )
+
+            try dataContainer.encode(id, forKey: NestedDataCodingKeys.id)
+            try dataContainer.encode(`class`, forKey: NestedDataCodingKeys.`class`)
+            try dataContainer.encode(`private`, forKey: NestedDataCodingKeys.`private`)
           }
         }
         """,

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
@@ -127,4 +127,47 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
     throw XCTSkip("macros are only supported when running tests for the host platform")
     #endif
   }
+
+  func testUnnestedPolymorphicDecodableMacroWithoutProperties() throws {
+    #if canImport(KarrotCodableKitMacros)
+    assertMacroExpansion(
+      """
+      @UnnestedPolymorphicDecodable(
+        identifier: "TITLE_VIEW_ITEM",
+        forKey: "some_data",
+        codingKeyStyle: .snakeCase
+      )
+      struct TitleViewItem: ViewItem {
+
+      }
+      """,
+      expandedSource: """
+        struct TitleViewItem: ViewItem {
+
+          private enum CodingKeys: String, CodingKey {
+            case some_data
+          }
+
+          private enum NestedDataCodingKeys: CodingKey {
+          }
+
+        }
+
+        extension TitleViewItem: PolymorphicDecodableType {
+          static var polymorphicIdentifier: String {
+            "TITLE_VIEW_ITEM"
+          }
+
+          init(from decoder: any Decoder) throws {
+
+          }
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2)
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
 }

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
@@ -40,12 +40,12 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
           let title: String?
 
           private enum CodingKeys: String, CodingKey {
-            case data
+            case `data`
           }
 
           private enum NestedDataCodingKeys: String, CodingKey {
-            case id
-            case title
+            case `id`
+            case `title`
           }
         }
 
@@ -94,12 +94,12 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
           let itemTitle: String?
 
           private enum CodingKeys: String, CodingKey {
-            case data
+            case `data`
           }
 
           private enum NestedDataCodingKeys: String, CodingKey {
-            case id
-            case itemTitle = "item_title"
+            case `id`
+            case `itemTitle` = "item_title"
           }
         }
 
@@ -145,7 +145,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         struct TitleViewItem: ViewItem {
 
           private enum CodingKeys: String, CodingKey {
-            case some_data
+            case `some_data`
           }
 
           private enum NestedDataCodingKeys: CodingKey {


### PR DESCRIPTION
## Background (Required)
<!-- Describe the background for this work. -->
- UnnestedPolymorphicCodable macro had two types of compiler errors:
  1. Compilation failure due to empty NestedDataCodingKeys enum when struct has no properties
  2. Compilation failure due to unescaped case names when property names match Swift reserved keywords

## Changes
<!-- List the changes explicitly. -->
- Fix empty CodingKeys enum generation for structs without properties
- Wrap all CodingKeys case names with backticks for proper Swift keyword escaping
- Handle both empty cases and keyword escaping in `CodingKeysSyntaxFactory.makeCodingKeysCases()` method
- Apply fixes to both top-level `CodingKeys` and nested `NestedDataCodingKeys` enums

## Testing Methods
<!-- Describe how to test the changes. -->
- Add test cases for empty structs without properties
- Add test cases with Swift keyword property names (e.g., `class`, `default`, `import`)
- Verify macro expansion generates proper empty enums and backtick-escaped case names
- Validate existing functionality remains unaffected

## Review Notes
<!-- Include any information that would help with the review. -->
- Critical fix for two major compilation errors in UnnestedPolymorphicCodable macro
- Supports both empty structs and Swift keyword properties
- Generates safe code following Swift's standard conventions
- No breaking changes to existing API or functionality