### PR TITLE
refactor: remove projectedValue when non-DEBUG builds

### DIFF
--- a/Sources/KarrotCodableKit/BetterCodable/DataValue/DataValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DataValue/DataValue.swift
@@ -38,7 +38,9 @@ public struct DataValue<Coder: DataValueCodableStrategy> {
   }
 
   #if DEBUG
-  public var projectedValue: ResilientProjectedValue { ResilientProjectedValue(outcome: outcome) }
+  public var projectedValue: ResilientProjectedValue {
+    ResilientProjectedValue(outcome: outcome)
+  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/DateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/DateValue.swift
@@ -38,7 +38,9 @@ public struct DateValue<Formatter: DateValueCodableStrategy> {
   }
 
   #if DEBUG
-  public var projectedValue: ResilientProjectedValue { ResilientProjectedValue(outcome: outcome) }
+  public var projectedValue: ResilientProjectedValue {
+    ResilientProjectedValue(outcome: outcome)
+  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/OptionalDateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/OptionalDateValue.swift
@@ -39,7 +39,9 @@ public struct OptionalDateValue<Formatter: OptionalDateValueCodableStrategy> {
   }
 
   #if DEBUG
-  public var projectedValue: ResilientProjectedValue { ResilientProjectedValue(outcome: outcome) }
+  public var projectedValue: ResilientProjectedValue {
+    ResilientProjectedValue(outcome: outcome)
+  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultCodable.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultCodable.swift
@@ -49,7 +49,9 @@ public struct DefaultCodable<Default: DefaultCodableStrategy> {
   }
 
   #if DEBUG
-  public var projectedValue: ResilientProjectedValue { ResilientProjectedValue(outcome: outcome) }
+  public var projectedValue: ResilientProjectedValue {
+    ResilientProjectedValue(outcome: outcome)
+  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyArray.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyArray.swift
@@ -29,7 +29,9 @@ public struct LossyArray<T> {
   }
 
   #if DEBUG
-  public var projectedValue: ResilientArrayProjectedValue<T> { ResilientArrayProjectedValue(outcome: outcome) }
+  public var projectedValue: ResilientArrayProjectedValue<T> {
+    ResilientArrayProjectedValue(outcome: outcome)
+  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/DefaultEmptyPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/DefaultEmptyPolymorphicArrayValue.swift
@@ -49,11 +49,6 @@ public struct DefaultEmptyPolymorphicArrayValue<PolymorphicType: PolymorphicCoda
   public var projectedValue: PolymorphicProjectedValue {
     PolymorphicProjectedValue(outcome: outcome)
   }
-  #else
-  /// In non-DEBUG builds, accessing projectedValue is a programmer error
-  public var projectedValue: Never {
-    fatalError("@\(Self.self) projectedValue should not be used in non-DEBUG builds")
-  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/LossyOptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/LossyOptionalPolymorphicValue.swift
@@ -47,11 +47,6 @@ public struct LossyOptionalPolymorphicValue<PolymorphicType: PolymorphicCodableS
   public var projectedValue: PolymorphicProjectedValue {
     PolymorphicProjectedValue(outcome: outcome)
   }
-  #else
-  /// In non-DEBUG builds, accessing projectedValue is a programmer error
-  public var projectedValue: Never {
-    fatalError("@\(Self.self) projectedValue should not be used in non-DEBUG builds")
-  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicValue.swift
@@ -44,11 +44,6 @@ public struct OptionalPolymorphicValue<PolymorphicType: PolymorphicCodableStrate
   public var projectedValue: PolymorphicProjectedValue {
     PolymorphicProjectedValue(outcome: outcome)
   }
-  #else
-  /// In non-DEBUG builds, accessing projectedValue is a programmer error
-  public var projectedValue: Never {
-    fatalError("@\(Self.self) projectedValue should not be used in non-DEBUG builds")
-  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicArrayValue.swift
@@ -39,11 +39,6 @@ public struct PolymorphicArrayValue<PolymorphicType: PolymorphicCodableStrategy>
   public var projectedValue: PolymorphicProjectedValue {
     PolymorphicProjectedValue(outcome: outcome)
   }
-  #else
-  /// In non-DEBUG builds, accessing projectedValue is a programmer error
-  public var projectedValue: Never {
-    fatalError("@\(Self.self) projectedValue should not be used in non-DEBUG builds")
-  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicLossyArrayValue.swift
@@ -78,11 +78,6 @@ public struct PolymorphicLossyArrayValue<PolymorphicType: PolymorphicCodableStra
   public var projectedValue: PolymorphicLossyArrayProjectedValue<PolymorphicType.ExpectedType> {
     PolymorphicLossyArrayProjectedValue(outcome: outcome, results: results)
   }
-  #else
-  /// In non-DEBUG builds, accessing projectedValue is a programmer error
-  public var projectedValue: Never {
-    fatalError("@\(Self.self) projectedValue should not be used in non-DEBUG builds")
-  }
   #endif
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicValue.swift
@@ -38,7 +38,9 @@ public struct PolymorphicValue<PolymorphicType: PolymorphicCodableStrategy> {
   }
 
   #if DEBUG
-  public var projectedValue: PolymorphicProjectedValue { PolymorphicProjectedValue(outcome: outcome) }
+  public var projectedValue: PolymorphicProjectedValue {
+    PolymorphicProjectedValue(outcome: outcome)
+  }
   #endif
 }
 


### PR DESCRIPTION
## Background (Required)
<!-- Describe the background for this work. -->
- Compiler errors are better than fatalError

## Changes
<!-- List the changes explicitly. -->
- refactor: remove projectedValue when non-DEBUG builds

## Testing Methods
<!-- Describe how to test the changes. -->
- swift test

## Review Notes
<!-- Include any information that would help with the review. -->
- x