### PR TITLE
fix: Fixed compiler error when using `@PolymorphicCodableStrategyProviding` macro on protocols defined inside nested types

### DIFF
--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
@@ -25,7 +25,7 @@ import Foundation
                    when no matching type is found. The default value for this property is `nil`.
  */
 @attached(peer, names: suffixed(CodableStrategy))
-@attached(extension, names: arbitrary)
+@attached(member, names: arbitrary)
 public macro PolymorphicCodableStrategyProviding(
   identifierCodingKey: String = "type",
   matchingTypes: [PolymorphicDecodableType.Type],

--- a/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableStrategyMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableStrategyMacro.swift
@@ -10,15 +10,44 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-public struct PolymorphicCodableStrategyProvidingMacro: PeerMacro {
+public struct PolymorphicCodableStrategyProvidingMacro {}
+
+// MARK: - MemberMacro
+
+extension PolymorphicCodableStrategyProvidingMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    providingPeersOf declaration: some DeclSyntaxProtocol,
+    providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
       throw CodableKitError.message("Macro must be attached to a protocol.")
     }
+
+    let identifier = protocolDecl.name.text
+    let strategyStructName = "\(identifier)CodableStrategy"
+
+    return [
+      DeclSyntax("typealias Polymorphic = PolymorphicValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias OptionalPolymorphic = OptionalPolymorphicValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias PolymorphicArray = PolymorphicArrayValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<\(raw: strategyStructName)>"),
+      DeclSyntax("typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<\(raw: strategyStructName)>"),
+    ]
+  }
+}
+
+// MARK: - PeerMacro
+
+extension PolymorphicCodableStrategyProvidingMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else { return [] }
 
     guard
       let arguments = node.arguments?.as(LabeledExprListSyntax.self),
@@ -78,41 +107,5 @@ public struct PolymorphicCodableStrategyProvidingMacro: PeerMacro {
   private static func accessModifier(from protocolDecl: ProtocolDeclSyntax) -> String {
     guard protocolDecl.accessLevel != .internal else { return "" }
     return protocolDecl.accessLevel.rawValue + " "
-  }
-}
-
-extension PolymorphicCodableStrategyProvidingMacro: ExtensionMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
-  ) throws -> [ExtensionDeclSyntax] {
-    guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else { return [] }
-
-    let accessModifier = accessModifier(from: protocolDecl)
-    let identifier = protocolDecl.name.text
-    let strategyStructName = "\(identifier)CodableStrategy"
-
-    return [
-      try ExtensionDeclSyntax(
-        """
-        extension \(raw: identifier) {
-          \(raw: accessModifier)typealias Polymorphic = PolymorphicValue<\(raw: strategyStructName)>
-          \(raw: accessModifier)typealias OptionalPolymorphic = OptionalPolymorphicValue<\(raw: strategyStructName)>
-          \(raw: accessModifier)typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<\(
-            raw: strategyStructName
-          )>
-          \(raw: accessModifier)typealias PolymorphicArray = PolymorphicArrayValue<\(raw: strategyStructName)>
-          \(raw: accessModifier)typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<\(raw: strategyStructName)>
-          \(raw: accessModifier)typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<\(raw: strategyStructName)>
-          \(raw: accessModifier)typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<\(
-            raw: strategyStructName
-          )>
-        }
-        """
-      ),
-    ]
   }
 }

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableStrategyProvidingMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableStrategyProvidingMacroTests.swift
@@ -45,11 +45,24 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
       """,
       // when
       expandedSource: """
-
         public protocol Notice: Codable {
           var type: String { get }
           var title: String? { get }
           var description: String { get }
+
+          typealias Polymorphic = PolymorphicValue<NoticeCodableStrategy>
+
+          typealias OptionalPolymorphic = OptionalPolymorphicValue<NoticeCodableStrategy>
+
+          typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<NoticeCodableStrategy>
+
+          typealias PolymorphicArray = PolymorphicArrayValue<NoticeCodableStrategy>
+
+          typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<NoticeCodableStrategy>
+
+          typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<NoticeCodableStrategy>
+
+          typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<NoticeCodableStrategy>
         }
 
         public struct NoticeCodableStrategy: PolymorphicCodableStrategy {
@@ -71,16 +84,6 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
               fallbackType: UndefinedCallout.self
             )
           }
-        }
-
-        extension Notice {
-          public typealias Polymorphic = PolymorphicValue<NoticeCodableStrategy>
-          public typealias OptionalPolymorphic = OptionalPolymorphicValue<NoticeCodableStrategy>
-          public typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<NoticeCodableStrategy>
-          public typealias PolymorphicArray = PolymorphicArrayValue<NoticeCodableStrategy>
-          public typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<NoticeCodableStrategy>
-          public typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<NoticeCodableStrategy>
-          public typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<NoticeCodableStrategy>
         }
         """,
       macros: testMacros,
@@ -114,6 +117,20 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
           var type: String { get }
           var title: String? { get }
           var description: String { get }
+
+          typealias Polymorphic = PolymorphicValue<NoticeCodableStrategy>
+
+          typealias OptionalPolymorphic = OptionalPolymorphicValue<NoticeCodableStrategy>
+
+          typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<NoticeCodableStrategy>
+
+          typealias PolymorphicArray = PolymorphicArrayValue<NoticeCodableStrategy>
+
+          typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<NoticeCodableStrategy>
+
+          typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<NoticeCodableStrategy>
+
+          typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<NoticeCodableStrategy>
         }
 
         public struct NoticeCodableStrategy: PolymorphicCodableStrategy {
@@ -135,16 +152,6 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
               fallbackType: nil
             )
           }
-        }
-
-        extension Notice {
-          public typealias Polymorphic = PolymorphicValue<NoticeCodableStrategy>
-          public typealias OptionalPolymorphic = OptionalPolymorphicValue<NoticeCodableStrategy>
-          public typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<NoticeCodableStrategy>
-          public typealias PolymorphicArray = PolymorphicArrayValue<NoticeCodableStrategy>
-          public typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<NoticeCodableStrategy>
-          public typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<NoticeCodableStrategy>
-          public typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<NoticeCodableStrategy>
         }
         """,
       macros: testMacros,
@@ -216,15 +223,19 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
           var type: String
           var title: String?
           var description: String
-        }
 
-        extension Notice {
           typealias Polymorphic = PolymorphicValue<NoticeCodableStrategy>
+
           typealias OptionalPolymorphic = OptionalPolymorphicValue<NoticeCodableStrategy>
+
           typealias LossyOptionalPolymorphic = LossyOptionalPolymorphicValue<NoticeCodableStrategy>
+
           typealias PolymorphicArray = PolymorphicArrayValue<NoticeCodableStrategy>
+
           typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<NoticeCodableStrategy>
+
           typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<NoticeCodableStrategy>
+
           typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<NoticeCodableStrategy>
         }
         """,


### PR DESCRIPTION
## Background (Required)
- Fixed compiler error when using `@PolymorphicCodableStrategyProviding` macro on protocols defined inside nested types

## Changes
- Changed macro attachment from `@attached(extension)` to `@attached(member)` for `PolymorphicCodableStrategyProviding`
- Moved typealias generation from protocol extension to protocol member declarations
- This allows the macro to work correctly when the protocol is defined within a nested type context

## Testing Methods
- Run existing macro expansion tests to verify backward compatibility
- Test the macro on protocols defined inside nested types (structs/classes/enums)

## Review Notes
- This change maintains the same functionality while resolving compilation issues in nested type contexts
- All existing tests continue to pass with updated expansion expectations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Protocols annotated with the macro now get a nested CodableStrategy and convenient polymorphic typealiases directly inside the protocol.
  - Improved access modifier handling for generated members.
  - Added validation for required inputs (non-empty identifier key, matching types present).

- Refactor
  - Switched macro expansion to attach members instead of using extensions for a more seamless API.

- Tests
  - Updated tests to expect typealiases within the protocol body rather than in an extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->