### PR TITLE
chore: bump macOS support version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
   name: "KarrotCodableKit",
-  platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+  platforms: [.macOS(.v11), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
   products: [
     .library(
       name: "KarrotCodableKit",


### PR DESCRIPTION
## Background (Required)
<!-- Describe the background for this work. -->
- bump macOS support version

## Changes
<!-- List the changes explicitly. -->
- chore: bump macOS support version

## Testing Methods
<!-- Describe how to test the changes. -->
- ci

## Review Notes
<!-- Include any information that would help with the review. -->
- x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported macOS version to 11. The app now requires macOS 11 or later.
  * Users on macOS 10.15 (Catalina) and earlier are no longer supported.
  * iOS (13+), tvOS (13+), watchOS (6+), and macCatalyst (13+) minimum versions remain unchanged.
  * No changes to features, dependencies, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->