### PR TITLE
fix: Fixed compiler error when using @PolymorphicEnumCodable macro on enums defined inside nested types

### DIFF
--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumCodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumCodable.swift
@@ -7,36 +7,29 @@
 
 import Foundation
 
-/**
- A macro that makes enum types polymorphically codable.
-
- This macro adds Codable conformance to enum types, allowing them to be serialized and
- deserialized based on a type identifier. It generates the necessary coding keys,
- initializer, and encoding methods.
-
- Each enum case must have exactly one associated value, and the type of that value must conform
- to `PolymorphicIdentifiable`.
-
- - Parameters:
-   - identifierCodingKey: The key name in the JSON used to store the type identifier.
-      The default value for this property is `"type"`. This key is used to identify the specific
-      case of the enum during
-   - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
-      The default value for this property is `nil`. If this property is not provided, the macro will
-      throw an error if the type identifier is not found.
-
- - Warning: When decoding falls back to the fallback case, during encoding the original `type` value
-      will not be preserved. Instead, the `type` value of the fallback case will be used in the
-      encoded output.
- */
-@attached(
-  extension,
-  conformances: Codable,
-  names: named(PolymorphicMetaCodingKey),
-  named(init),
-  named(encode)
-)
+/// A macro that makes enum types polymorphically codable.
+///
+/// This macro adds Codable conformance to enum types, allowing them to be serialized and
+/// deserialized based on a type identifier. It generates the necessary coding keys,
+/// initializer, and encoding methods.
+///
+/// Each enum case must have exactly one associated value, and the type of that value must conform
+/// to `PolymorphicIdentifiable`.
+///
+/// - Parameters:
+///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
+///     The default value for this property is `"type"`. This key is used to identify the specific
+///     case of the enum during
+///  - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
+///     The default value for this property is `nil`. If this property is not provided, the macro will
+///     throw an error if the type identifier is not found.
+///
+/// - Warning: When decoding falls back to the fallback case, during encoding the original `type` value
+///     will not be preserved. Instead, the `type` value of the fallback case will be used in the
+///     encoded output.
+@attached(member, names: named(PolymorphicMetaCodingKey), named(init), named(encode))
+@attached(extension, conformances: Codable)
 public macro PolymorphicEnumCodable(
   identifierCodingKey: String = "type",
-  fallbackCaseName: String? = nil
+  fallbackCaseName: String? = nil,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicEnumCodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumCodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumCodable.swift
@@ -19,7 +19,7 @@ import Foundation
 /// - Parameters:
 ///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
 ///     The default value for this property is `"type"`. This key is used to identify the specific
-///     case of the enum during
+///     case of the enum during encoding and decoding.
 ///  - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
 ///     The default value for this property is `nil`. If this property is not provided, the macro will
 ///     throw an error if the type identifier is not found.

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumDecodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumDecodable.swift
@@ -18,7 +18,7 @@ import Foundation
 /// - Parameters:
 ///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
 ///     The default value for this property is `"type"`. This key is used to identify the specific
-///     case of the enum during
+///     case of the enum during decoding.
 ///  - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
 ///     The default value for this property is `nil`. If this property is not provided, the macro will
 ///     throw an error if the type identifier is not found.

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumDecodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumDecodable.swift
@@ -7,25 +7,24 @@
 
 import Foundation
 
-/**
- A macro that makes enum types polymorphically decodable.
-
- This macro adds Decodable conformance to enum types, allowing them to be deserialized
- based on a type identifier. It generates the necessary coding keys and initializer methods.
-
- Each enum case must have exactly one associated value, and the type of that value must conform to
- `PolymorphicIdentifiable`.
-
- - Parameters:
-   - identifierCodingKey: The key name in the JSON used to store the type identifier.
-      The default value for this property is `"type"`. This key is used to identify the specific
-      case of the enum during
-   - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
-      The default value for this property is `nil`. If this property is not provided, the macro will
-      throw an error if the type identifier is not found.
- */
-@attached(extension, conformances: Decodable, names: named(PolymorphicMetaCodingKey), named(init))
+/// A macro that makes enum types polymorphically decodable.
+///
+/// This macro adds Decodable conformance to enum types, allowing them to be deserialized
+/// based on a type identifier. It generates the necessary coding keys and initializer methods.
+///
+/// Each enum case must have exactly one associated value, and the type of that value must conform to
+/// `PolymorphicIdentifiable`.
+///
+/// - Parameters:
+///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
+///     The default value for this property is `"type"`. This key is used to identify the specific
+///     case of the enum during
+///  - fallbackCaseName: The name of the `case` to use when the type identifier is not found.
+///     The default value for this property is `nil`. If this property is not provided, the macro will
+///     throw an error if the type identifier is not found.
+@attached(member, names: named(PolymorphicMetaCodingKey), named(init))
+@attached(extension, conformances: Decodable)
 public macro PolymorphicEnumDecodable(
   identifierCodingKey: String = "type",
-  fallbackCaseName: String? = nil
+  fallbackCaseName: String? = nil,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicEnumDecodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumEncodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumEncodable.swift
@@ -7,21 +7,20 @@
 
 import Foundation
 
-/**
- A macro that makes enum types polymorphically encodable.
-
- This macro adds Encodable conformance to enum types, allowing them to be serialized
- based on a type identifier. It generates the necessary coding keys and encoding methods.
-
- Each enum case must have exactly one associated value, and the type of that value must conform
- to `PolymorphicIdentifiable`.
-
- - Parameters:
-   - identifierCodingKey: The key name in the JSON used to store the type identifier.
-      The default value for this property is `"type"`. This key is used to identify the specific
-      case of the enum during
- */
-@attached(extension, conformances: Encodable, names: named(PolymorphicMetaCodingKey), named(encode))
+/// A macro that makes enum types polymorphically encodable.
+///
+/// This macro adds Encodable conformance to enum types, allowing them to be serialized
+/// based on a type identifier. It generates the necessary coding keys and encoding methods.
+///
+/// Each enum case must have exactly one associated value, and the type of that value must conform
+/// to `PolymorphicIdentifiable`.
+///
+/// - Parameters:
+///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
+///     The default value for this property is `"type"`. This key is used to identify the specific
+///     case of the enum during
+@attached(member, names: named(PolymorphicMetaCodingKey), named(encode))
+@attached(extension, conformances: Encodable)
 public macro PolymorphicEnumEncodable(
   identifierCodingKey: String = "type"
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicEnumEncodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumEncodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEnumEncodable.swift
@@ -18,8 +18,8 @@ import Foundation
 /// - Parameters:
 ///  - identifierCodingKey: The key name in the JSON used to store the type identifier.
 ///     The default value for this property is `"type"`. This key is used to identify the specific
-///     case of the enum during
-@attached(member, names: named(PolymorphicMetaCodingKey), named(encode))
+///     case of the enum during encoding.
+@attached(member, names: named(encode))
 @attached(extension, conformances: Encodable)
 public macro PolymorphicEnumEncodable(
   identifierCodingKey: String = "type"

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumCodableMacro.swift
@@ -55,15 +55,19 @@ public struct PolymorphicEnumCodableMacro: MemberMacro {
 
 extension PolymorphicEnumCodableMacro: ExtensionMacro {
   public static func expansion(
-    of _: AttributeSyntax,
+    of node: AttributeSyntax,
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo _: [TypeSyntax],
     in _: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
-    guard declaration.is(EnumDeclSyntax.self) else {
-      return []
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw CodableKitError.message("`@PolymorphicEnumCodable` can only be attached to enums")
     }
+
+    try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
+    let caseInfos = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
+    try PolymorphicEnumCodableFactory.validateFallbackCaseName(in: node, caseInfos: caseInfos)
 
     return try [ExtensionDeclSyntax("extension \(type.trimmed): Codable {}")]
   }

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumCodableMacro.swift
@@ -10,29 +10,21 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct PolymorphicEnumCodableMacro: ExtensionMacro {
+public struct PolymorphicEnumCodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
-  ) throws -> [ExtensionDeclSyntax] {
-    // Ensure the declaration is an enum and extract case information
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in _: some MacroExpansionContext,
+  ) throws -> [DeclSyntax] {
     guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
       throw CodableKitError.message("`@PolymorphicEnumCodable` can only be attached to enums")
     }
 
-    // Validate and extract identifierCodingKey
     let identifierCodingKey = try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
-
-    // Extract case information from the enum
     let caseInfos = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
-
-    // Validate and extract fallbackCaseName if provided
     let fallbackCaseName = try PolymorphicEnumCodableFactory.validateFallbackCaseName(
       in: node,
-      caseInfos: caseInfos
+      caseInfos: caseInfos,
     )
 
     let polymorphicMetaCodingKeySyntax = PolymorphicEnumCodableFactory.makePolymorphicMetaCodingKey(
@@ -45,24 +37,34 @@ public struct PolymorphicEnumCodableMacro: ExtensionMacro {
       with: caseInfos,
       identifierCodingKey: identifierCodingKey,
       accessLevel: accessLevel,
-      fallbackCaseName: fallbackCaseName
+      fallbackCaseName: fallbackCaseName,
     )
 
     let encodeToEncoderSyntax = PolymorphicEnumCodableFactory.makeEncodeToEncoder(
       with: caseInfos,
-      accessLevel: accessLevel
+      accessLevel: accessLevel,
     )
 
     return [
-      try ExtensionDeclSyntax("extension \(raw: enumDecl.name.text): Codable") {
-        """
-        \(raw: polymorphicMetaCodingKeySyntax)
-
-        \(raw: initFromDecoderSyntax)
-
-        \(raw: encodeToEncoderSyntax)
-        """
-      },
+      "\(raw: polymorphicMetaCodingKeySyntax)",
+      "\(raw: initFromDecoderSyntax)",
+      "\(raw: encodeToEncoderSyntax)",
     ]
+  }
+}
+
+extension PolymorphicEnumCodableMacro: ExtensionMacro {
+  public static func expansion(
+    of _: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo _: [TypeSyntax],
+    in _: some MacroExpansionContext,
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(EnumDeclSyntax.self) else {
+      return []
+    }
+
+    return try [ExtensionDeclSyntax("extension \(type.trimmed): Codable {}")]
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumDecodableMacro.swift
@@ -49,15 +49,19 @@ public struct PolymorphicEnumDecodableMacro: MemberMacro {
 
 extension PolymorphicEnumDecodableMacro: ExtensionMacro {
   public static func expansion(
-    of _: AttributeSyntax,
+    of node: AttributeSyntax,
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo _: [TypeSyntax],
     in _: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
-    guard declaration.is(EnumDeclSyntax.self) else {
-      return []
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw CodableKitError.message("`@PolymorphicEnumDecodable` can only be attached to enums")
     }
+
+    try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
+    let caseInfos = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
+    try PolymorphicEnumCodableFactory.validateFallbackCaseName(in: node, caseInfos: caseInfos)
 
     return try [ExtensionDeclSyntax("extension \(type.trimmed): Decodable {}")]
   }

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumDecodableMacro.swift
@@ -6,35 +6,25 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Foundation
-
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct PolymorphicEnumDecodableMacro: ExtensionMacro {
+public struct PolymorphicEnumDecodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
-  ) throws -> [ExtensionDeclSyntax] {
-    // Ensure the declaration is an enum and extract case information
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in _: some MacroExpansionContext,
+  ) throws -> [DeclSyntax] {
     guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
       throw CodableKitError.message("`@PolymorphicEnumDecodable` can only be attached to enums")
     }
 
-    // Validate and extract identifierCodingKey
     let identifierCodingKey = try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
-
-    // Extract case information from the enum
     let caseInfos = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
-
-    // Validate and extract fallbackCaseName if provided
     let fallbackCaseName = try PolymorphicEnumCodableFactory.validateFallbackCaseName(
       in: node,
-      caseInfos: caseInfos
+      caseInfos: caseInfos,
     )
 
     let polymorphicMetaCodingKeySyntax = PolymorphicEnumCodableFactory.makePolymorphicMetaCodingKey(
@@ -47,17 +37,28 @@ public struct PolymorphicEnumDecodableMacro: ExtensionMacro {
       with: caseInfos,
       identifierCodingKey: identifierCodingKey,
       accessLevel: accessLevel,
-      fallbackCaseName: fallbackCaseName
+      fallbackCaseName: fallbackCaseName,
     )
 
     return [
-      try ExtensionDeclSyntax("extension \(raw: enumDecl.name.text): Decodable") {
-        """
-        \(raw: polymorphicMetaCodingKeySyntax)
-
-        \(raw: initFromDecoderSyntax)
-        """
-      },
+      "\(raw: polymorphicMetaCodingKeySyntax)",
+      "\(raw: initFromDecoderSyntax)",
     ]
+  }
+}
+
+extension PolymorphicEnumDecodableMacro: ExtensionMacro {
+  public static func expansion(
+    of _: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo _: [TypeSyntax],
+    in _: some MacroExpansionContext,
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(EnumDeclSyntax.self) else {
+      return []
+    }
+
+    return try [ExtensionDeclSyntax("extension \(type.trimmed): Decodable {}")]
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumEncodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumEncodableMacro.swift
@@ -10,38 +10,44 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-public struct PolymorphicEnumEncodableMacro: ExtensionMacro {
+public struct PolymorphicEnumEncodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
-    attachedTo declaration: some DeclGroupSyntax,
-    providingExtensionsOf type: some TypeSyntaxProtocol,
-    conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
-  ) throws -> [ExtensionDeclSyntax] {
-    // Ensure the declaration is an enum and extract case information
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in _: some MacroExpansionContext,
+  ) throws -> [DeclSyntax] {
     guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
       throw CodableKitError.message("`@PolymorphicEnumEncodable` can only be attached to enums")
     }
 
-    // Validate identifierCodingKey
     try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
 
-    // Extract case information from the enum
     let caseInfos = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
-
     let accessLevel = AccessLevelModifier.stringValue(from: declaration)
 
     let encodeToEncoderSyntax = PolymorphicEnumCodableFactory.makeEncodeToEncoder(
       with: caseInfos,
-      accessLevel: accessLevel
+      accessLevel: accessLevel,
     )
 
     return [
-      try ExtensionDeclSyntax("extension \(raw: enumDecl.name.text): Encodable") {
-        """
-        \(raw: encodeToEncoderSyntax)
-        """
-      },
+      "\(raw: encodeToEncoderSyntax)"
     ]
+  }
+}
+
+extension PolymorphicEnumEncodableMacro: ExtensionMacro {
+  public static func expansion(
+    of _: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo _: [TypeSyntax],
+    in _: some MacroExpansionContext,
+  ) throws -> [ExtensionDeclSyntax] {
+    guard declaration.is(EnumDeclSyntax.self) else {
+      return []
+    }
+
+    return try [ExtensionDeclSyntax("extension \(type.trimmed): Encodable {}")]
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumEncodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicEnumCodableMacros/PolymorphicEnumEncodableMacro.swift
@@ -38,15 +38,18 @@ public struct PolymorphicEnumEncodableMacro: MemberMacro {
 
 extension PolymorphicEnumEncodableMacro: ExtensionMacro {
   public static func expansion(
-    of _: AttributeSyntax,
+    of node: AttributeSyntax,
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo _: [TypeSyntax],
     in _: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
-    guard declaration.is(EnumDeclSyntax.self) else {
-      return []
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw CodableKitError.message("`@PolymorphicEnumEncodable` can only be attached to enums")
     }
+
+    try PolymorphicEnumCodableFactory.validateIdentifierCodingKey(in: node)
+    _ = try PolymorphicEnumCodableFactory.extractCaseInfos(from: enumDecl)
 
     return try [ExtensionDeclSyntax("extension \(type.trimmed): Encodable {}")]
   }

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
@@ -1,5 +1,5 @@
 //
-//  PolymorphicEnumCodableEnumMacroTests.swift
+//  PolymorphicEnumCodableMacroTests.swift
 //
 //
 //  Created by Elon on 10/19/24.
@@ -15,10 +15,9 @@ import KarrotCodableKitMacros
 #endif
 
 final class PolymorphicEnumCodableMacroTests: XCTestCase {
-
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicEnumCodable": PolymorphicEnumCodableMacro.self,
+    "PolymorphicEnumCodable": PolymorphicEnumCodableMacro.self
   ]
   #endif
 
@@ -41,9 +40,7 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -75,9 +72,12 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -103,9 +103,7 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -137,9 +135,12 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -170,11 +171,11 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "`@PolymorphicEnumCodable` can only be attached to enums",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -200,16 +201,19 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -235,16 +239,19 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -270,16 +277,83 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
+}
+
+// MARK: - Nested Type
+
+extension PolymorphicEnumCodableMacroTests {
+  func testPolymorphicEnumCodableMacroInsideNestedType() throws {
+    #if canImport(KarrotCodableKitMacros)
+    // given
+    assertMacroExpansion(
+      """
+      enum SomeEnum {
+        @PolymorphicEnumCodable(identifierCodingKey: "type")
+        public enum CalloutBadge {
+          case callout(DummyCallout)
+          case actionableCallout(DummyActionableCallout)
+        }
+      }
+      """,
+      // when
+      expandedSource: """
+        enum SomeEnum {
+          public enum CalloutBadge {
+            case callout(DummyCallout)
+            case actionableCallout(DummyActionableCallout)
+
+            enum PolymorphicMetaCodingKey: CodingKey {
+              case `type`
+            }
+
+            public init(from decoder: any Decoder) throws {
+              let container = try decoder.container(keyedBy: PolymorphicMetaCodingKey.self)
+              let type = try container.decode(String.self, forKey: PolymorphicMetaCodingKey.type)
+
+              switch type {
+              case DummyCallout.polymorphicIdentifier:
+                self = .callout(try DummyCallout(from: decoder))
+               case DummyActionableCallout.polymorphicIdentifier:
+                self = .actionableCallout(try DummyActionableCallout(from: decoder))
+              default:
+                throw PolymorphicCodableError.unableToFindPolymorphicType(type)
+              }
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+              switch self {
+              case .callout(let value):
+                try value.encode(to: encoder)
+               case .actionableCallout(let value):
+                try value.encode(to: encoder)
+              }
+            }
+          }
+        }
+
+        extension SomeEnum.CalloutBadge: Codable {
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -311,9 +385,7 @@ extension PolymorphicEnumCodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
           case undefinedCallout(DummyUndefinedCallout)
-        }
 
-        extension CalloutBadge: Codable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -349,9 +421,12 @@ extension PolymorphicEnumCodableMacroTests {
             }
           }
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -377,16 +452,19 @@ extension PolymorphicEnumCodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Missing fallback case: should be defined as `case undefinedCallout",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -412,16 +490,19 @@ extension PolymorphicEnumCodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Codable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid fallback case name: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumCodableMacroTests.swift
@@ -172,7 +172,12 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           message: "`@PolymorphicEnumCodable` can only be attached to enums",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "`@PolymorphicEnumCodable` can only be attached to enums",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -201,16 +206,18 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Codable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Invalid polymorphic identifier: expected a non-empty string.",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -239,16 +246,18 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Codable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases can only have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -277,16 +286,18 @@ final class PolymorphicEnumCodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Codable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases should have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -452,16 +463,18 @@ extension PolymorphicEnumCodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Codable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Missing fallback case: should be defined as `case undefinedCallout",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Missing fallback case: should be defined as `case undefinedCallout",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -490,16 +503,18 @@ extension PolymorphicEnumCodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Codable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid fallback case name: expected a non-empty string.",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Invalid fallback case name: expected a non-empty string.",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
@@ -15,10 +15,9 @@ import KarrotCodableKitMacros
 #endif
 
 final class PolymorphicEnumDecodableMacroTests: XCTestCase {
-
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicEnumDecodable": PolymorphicEnumDecodableMacro.self,
+    "PolymorphicEnumDecodable": PolymorphicEnumDecodableMacro.self
   ]
   #endif
 
@@ -41,9 +40,7 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -64,9 +61,12 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -92,9 +92,7 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -115,9 +113,12 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -148,11 +149,11 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "`@PolymorphicEnumDecodable` can only be attached to enums",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -178,16 +179,19 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -213,16 +217,19 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -248,16 +255,74 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
+}
+
+// MARK: - Nested Type
+
+extension PolymorphicEnumDecodableMacroTests {
+  func testPolymorphicEnumDecodableMacroInsideNestedType() throws {
+    #if canImport(KarrotCodableKitMacros)
+    // given
+    assertMacroExpansion(
+      """
+      enum SomeEnum {
+        @PolymorphicEnumDecodable(identifierCodingKey: "type")
+        public enum CalloutBadge {
+          case callout(DummyCallout)
+          case actionableCallout(DummyActionableCallout)
+        }
+      }
+      """,
+      // when
+      expandedSource: """
+        enum SomeEnum {
+          public enum CalloutBadge {
+            case callout(DummyCallout)
+            case actionableCallout(DummyActionableCallout)
+
+            enum PolymorphicMetaCodingKey: CodingKey {
+              case `type`
+            }
+
+            public init(from decoder: any Decoder) throws {
+              let container = try decoder.container(keyedBy: PolymorphicMetaCodingKey.self)
+              let type = try container.decode(String.self, forKey: PolymorphicMetaCodingKey.type)
+
+              switch type {
+              case DummyCallout.polymorphicIdentifier:
+                self = .callout(try DummyCallout(from: decoder))
+               case DummyActionableCallout.polymorphicIdentifier:
+                self = .actionableCallout(try DummyActionableCallout(from: decoder))
+              default:
+                throw PolymorphicCodableError.unableToFindPolymorphicType(type)
+              }
+            }
+          }
+        }
+
+        extension SomeEnum.CalloutBadge: Decodable {
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -289,9 +354,7 @@ extension PolymorphicEnumDecodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
           case undefinedCallout(DummyUndefinedCallout)
-        }
 
-        extension CalloutBadge: Decodable {
           enum PolymorphicMetaCodingKey: CodingKey {
             case `type`
           }
@@ -314,9 +377,12 @@ extension PolymorphicEnumDecodableMacroTests {
             }
           }
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -342,16 +408,19 @@ extension PolymorphicEnumDecodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Missing fallback case: should be defined as `case undefinedCallout",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -377,16 +446,19 @@ extension PolymorphicEnumDecodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Decodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid fallback case name: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumDecodableMacroTests.swift
@@ -150,7 +150,12 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           message: "`@PolymorphicEnumDecodable` can only be attached to enums",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "`@PolymorphicEnumDecodable` can only be attached to enums",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -179,16 +184,18 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Decodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Invalid polymorphic identifier: expected a non-empty string.",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -217,16 +224,18 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Decodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases can only have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -255,16 +264,18 @@ final class PolymorphicEnumDecodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Decodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases should have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -408,16 +419,18 @@ extension PolymorphicEnumDecodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Decodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Missing fallback case: should be defined as `case undefinedCallout",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Missing fallback case: should be defined as `case undefinedCallout",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -446,16 +459,18 @@ extension PolymorphicEnumDecodableMacroTests {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Decodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid fallback case name: expected a non-empty string.",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Invalid fallback case name: expected a non-empty string.",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumEncodableMacroTests.swift
@@ -15,10 +15,9 @@ import KarrotCodableKitMacros
 #endif
 
 final class PolymorphicEnumEncodableMacroTests: XCTestCase {
-
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicEnumEncodable": PolymorphicEnumEncodableMacro.self,
+    "PolymorphicEnumEncodable": PolymorphicEnumEncodableMacro.self
   ]
   #endif
 
@@ -41,9 +40,7 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Encodable {
           public func encode(to encoder: any Encoder) throws {
             switch self {
             case .callout(let value):
@@ -55,9 +52,12 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Encodable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -83,9 +83,7 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case callout(DummyCallout)
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(value: DummyDismissibleCallout)
-        }
 
-        extension CalloutBadge: Encodable {
           public func encode(to encoder: any Encoder) throws {
             switch self {
             case .callout(let value):
@@ -97,9 +95,54 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
             }
           }
         }
+
+        extension CalloutBadge: Encodable {
+        }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
+    )
+    #else
+    throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+  }
+
+  func testPolymorphicEnumEncodableMacroInsideNestedType() throws {
+    #if canImport(KarrotCodableKitMacros)
+    // given
+    assertMacroExpansion(
+      """
+      enum SomeEnum {
+        @PolymorphicEnumEncodable(identifierCodingKey: "type")
+        public enum CalloutBadge {
+          case callout(DummyCallout)
+          case actionableCallout(DummyActionableCallout)
+        }
+      }
+      """,
+      // when
+      expandedSource: """
+        enum SomeEnum {
+          public enum CalloutBadge {
+            case callout(DummyCallout)
+            case actionableCallout(DummyActionableCallout)
+
+            public func encode(to encoder: any Encoder) throws {
+              switch self {
+              case .callout(let value):
+                try value.encode(to: encoder)
+               case .actionableCallout(let value):
+                try value.encode(to: encoder)
+              }
+            }
+          }
+        }
+
+        extension SomeEnum.CalloutBadge: Encodable {
+        }
+        """,
+      macros: testMacros,
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -130,11 +173,11 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "`@PolymorphicEnumEncodable` can only be attached to enums",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -160,16 +203,19 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Encodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -195,16 +241,19 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Encodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -230,16 +279,19 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
+
+        extension CalloutBadge: Encodable {
+        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicEnumCodableMacroTests/PolymorphicEnumEncodableMacroTests.swift
@@ -174,7 +174,12 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           message: "`@PolymorphicEnumEncodable` can only be attached to enums",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "`@PolymorphicEnumEncodable` can only be attached to enums",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -203,16 +208,18 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Encodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Invalid polymorphic identifier: expected a non-empty string.",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -241,16 +248,18 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Encodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases can only have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases can only have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),
@@ -279,16 +288,18 @@ final class PolymorphicEnumEncodableMacroTests: XCTestCase {
           case actionableCallout(DummyActionableCallout)
           case dismissibleCallout(DummyDismissibleCallout)
         }
-
-        extension CalloutBadge: Encodable {
-        }
         """,
       diagnostics: [
         DiagnosticSpec(
           message: "Polymorphic Enum cases should have one associated value",
           line: 1,
           column: 1,
-        )
+        ),
+        DiagnosticSpec(
+          message: "Polymorphic Enum cases should have one associated value",
+          line: 1,
+          column: 1,
+        ),
       ],
       macros: testMacros,
       indentationWidth: .spaces(2),


### PR DESCRIPTION
## Background (Required)
- Fixed compiler error when using `@PolymorphicEnumCodable`, `@PolymorphicEnumDecodable`, `@PolymorphicEnumEncodable` macros on enums defined inside nested types (Fixes #19)

## Changes
- Changed macro attachment from `@attached(extension)` to `@attached(member)` + `@attached(extension, conformances:)` for `PolymorphicEnumCodableMacro`, `PolymorphicEnumDecodableMacro`, `PolymorphicEnumEncodableMacro`
- Moved `PolymorphicMetaCodingKey`, `init(from:)`, `encode(to:)` generation from extension body to member declarations
- Extension macro now only provides protocol conformance with an empty body
- Added nested type macro expansion tests for all three macros

## Testing Methods
- Run existing macro expansion tests to verify backward compatibility
- Test the macro on enums defined inside nested types
```bash
swift test --filter "PolymorphicEnumCodableMacroTests|PolymorphicEnumDecodableMacroTests|PolymorphicEnumEncodableMacroTests"
```

## Review Notes
- This is the same fix pattern used in #15 for `@PolymorphicCodableStrategyProviding`
- When using `@attached(extension)`, generated code lives at top-level scope where sibling types within the parent namespace are not accessible by simple name. Converting to `@attached(member)` places the generated code inside the enum body, preserving the original type resolution scope
- All 152 tests pass with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked how polymorphic enum Codable behavior is generated internally to improve structure and maintainability.

* **Documentation**
  * Reformatted inline developer docs to doc-comment style for consistency.

* **Tests**
  * Updated expected macro expansion outputs and added tests covering nested-enum scenarios to validate the new generation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->