### PR TITLE
feat: omit nil optional fields on encode (IOS-4537)

### DIFF
--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/KeyedEncodingContainer+OptionalDateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/KeyedEncodingContainer+OptionalDateValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+OptionalDateValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an `OptionalDateValue`, omitting the key entirely when the wrapped value is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: OptionalDateValue<T>,
+    forKey key: Key
+  ) throws where T.RawValue: Encodable {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/KeyedEncodingContainer+OptionalLosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/KeyedEncodingContainer+OptionalLosslessValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+OptionalLosslessValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an `OptionalLosslessValueCodable`, omitting the key entirely when the wrapped value is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: OptionalLosslessValueCodable<T>,
+    forKey key: Key
+  ) throws where T: LosslessDecodingStrategy {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/BetterCodable/LossyValue/KeyedEncodingContainer+LossyOptional.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LossyValue/KeyedEncodingContainer+LossyOptional.swift
@@ -1,0 +1,28 @@
+//
+//  KeyedEncodingContainer+LossyOptional.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes a `@LossyOptional` value, omitting the key entirely when the wrapped value is `nil`.
+  ///
+  /// `LossyOptional` is a `DefaultCodable<DefaultNilStrategy>` alias, so this overload is constrained to
+  /// `DefaultNilStrategy` to target only the optional case. Other `DefaultCodable` wrappers
+  /// (`@DefaultFalse`, `@DefaultEmptyArray`, ...) keep encoding their non-optional default value.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as the default `nil`.
+  public mutating func encode<T>(
+    _ value: DefaultCodable<DefaultNilStrategy<T>>,
+    forKey key: Key
+  ) throws where T: Encodable {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+LossyOptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+LossyOptionalPolymorphicValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+LossyOptionalPolymorphicValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes a `LossyOptionalPolymorphicValue`, omitting the key entirely when the wrapped value is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: LossyOptionalPolymorphicValue<T>,
+    forKey key: Key
+  ) throws where T: PolymorphicCodableStrategy {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicArrayValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+OptionalPolymorphicArrayValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an `OptionalPolymorphicArrayValue`, omitting the key entirely when the wrapped array is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: OptionalPolymorphicArrayValue<T>,
+    forKey key: Key
+  ) throws where T: PolymorphicCodableStrategy {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicLossyArrayValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+OptionalPolymorphicLossyArrayValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an `OptionalPolymorphicLossyArrayValue`, omitting the key entirely when the wrapped array is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: OptionalPolymorphicLossyArrayValue<T>,
+    forKey key: Key
+  ) throws where T: PolymorphicCodableStrategy {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicValue.swift
@@ -1,0 +1,24 @@
+//
+//  KeyedEncodingContainer+OptionalPolymorphicValue.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+
+extension KeyedEncodingContainer {
+  /// Encodes an `OptionalPolymorphicValue`, omitting the key entirely when the wrapped value is `nil`.
+  ///
+  /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
+  /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
+  /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
+  public mutating func encode<T>(
+    _ value: OptionalPolymorphicValue<T>,
+    forKey key: Key
+  ) throws where T: PolymorphicCodableStrategy {
+    guard value.wrappedValue != nil else { return }
+    try value.encode(to: superEncoder(forKey: key))
+  }
+}

--- a/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicArrayValue.swift
@@ -30,7 +30,7 @@ import Foundation
 /// - Empty arrays are decoded as empty arrays, not `nil`
 ///
 /// Encoding behavior:
-/// - If `wrappedValue` is `nil`, encodes as `null`
+/// - If `wrappedValue` is `nil`, the key is omitted (a `null` is only produced inside an unkeyed container)
 /// - If `wrappedValue` contains an array, each element is encoded using the `PolymorphicType` strategy
 ///
 @propertyWrapper

--- a/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicLossyArrayValue.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-/// A property wrapper that decodes an optional array of polymorphic objects with lossy behavior for individual elements.
+/// A property wrapper that decodes an optional array of polymorphic objects with lossy behavior
+/// for individual elements.
 ///
 /// This wrapper combines the optionality handling of ``OptionalPolymorphicArrayValue`` with
 /// the lossy element decoding of ``PolymorphicLossyArrayValue``.
@@ -20,7 +21,8 @@ import Foundation
 /// Comparison with similar wrappers:
 /// - ``PolymorphicLossyArrayValue``: For required arrays that default to `[]` when missing or null
 /// - ``OptionalPolymorphicArrayValue``: For optional arrays that throw on invalid elements
-/// - ``DefaultEmptyPolymorphicArrayValue``: For required arrays that default to `[]` when missing or null, strict on elements
+/// - ``DefaultEmptyPolymorphicArrayValue``: For required arrays that default to `[]` when missing or null,
+///   strict on elements
 ///
 /// Decoding behavior:
 /// - If the key is missing or the value is `null`, `wrappedValue` is set to `nil`
@@ -29,7 +31,7 @@ import Foundation
 /// - Empty arrays are decoded as empty arrays, not `nil`
 ///
 /// Encoding behavior:
-/// - If `wrappedValue` is `nil`, encodes as `null`
+/// - If `wrappedValue` is `nil`, the key is omitted (a `null` is only produced inside an unkeyed container)
 /// - If `wrappedValue` contains an array, each element is encoded using the `PolymorphicType` strategy
 ///
 @propertyWrapper
@@ -42,40 +44,40 @@ public struct OptionalPolymorphicLossyArrayValue<PolymorphicType: PolymorphicCod
   public let outcome: ResilientDecodingOutcome
 
   #if DEBUG
-    /// Results of decoding each element in the array (DEBUG only)
-    let results: [Result<PolymorphicType.ExpectedType, Error>]
+  /// Results of decoding each element in the array (DEBUG only)
+  let results: [Result<PolymorphicType.ExpectedType, Error>]
   #endif
 
   public init(wrappedValue: [PolymorphicType.ExpectedType]?) {
     self.wrappedValue = wrappedValue
     outcome = .decodedSuccessfully
     #if DEBUG
-      results = []
+    results = []
     #endif
   }
 
   #if DEBUG
-    init(
-      wrappedValue: [PolymorphicType.ExpectedType]?,
-      outcome: ResilientDecodingOutcome,
-      results: [Result<PolymorphicType.ExpectedType, Error>] = []
-    ) {
-      self.wrappedValue = wrappedValue
-      self.outcome = outcome
-      self.results = results
-    }
+  init(
+    wrappedValue: [PolymorphicType.ExpectedType]?,
+    outcome: ResilientDecodingOutcome,
+    results: [Result<PolymorphicType.ExpectedType, Error>] = []
+  ) {
+    self.wrappedValue = wrappedValue
+    self.outcome = outcome
+    self.results = results
+  }
   #else
-    init(wrappedValue: [PolymorphicType.ExpectedType]?, outcome: ResilientDecodingOutcome) {
-      self.wrappedValue = wrappedValue
-      self.outcome = outcome
-    }
+  init(wrappedValue: [PolymorphicType.ExpectedType]?, outcome: ResilientDecodingOutcome) {
+    self.wrappedValue = wrappedValue
+    self.outcome = outcome
+  }
   #endif
 
   #if DEBUG
-    /// The projected value providing access to decoding outcome
-    public var projectedValue: PolymorphicLossyArrayProjectedValue<PolymorphicType.ExpectedType> {
-      PolymorphicLossyArrayProjectedValue(outcome: outcome, results: results)
-    }
+  /// The projected value providing access to decoding outcome
+  public var projectedValue: PolymorphicLossyArrayProjectedValue<PolymorphicType.ExpectedType> {
+    PolymorphicLossyArrayProjectedValue(outcome: outcome, results: results)
+  }
   #endif
 }
 
@@ -95,7 +97,7 @@ extension OptionalPolymorphicLossyArrayValue: Decodable {
 
     var elements = [PolymorphicType.ExpectedType]()
     #if DEBUG
-      var results = [Result<PolymorphicType.ExpectedType, Error>]()
+    var results = [Result<PolymorphicType.ExpectedType, Error>]()
     #endif
 
     while !container.isAtEnd {
@@ -103,21 +105,21 @@ extension OptionalPolymorphicLossyArrayValue: Decodable {
         let value = try container.decode(PolymorphicValue<PolymorphicType>.self).wrappedValue
         elements.append(value)
         #if DEBUG
-          results.append(.success(value))
+        results.append(.success(value))
         #endif
       } catch {
         // Decoding processing to prevent infinite loops if decoding fails.
         _ = try? container.decode(AnyDecodableValue.self)
         #if DEBUG
-          results.append(.failure(error))
+        results.append(.failure(error))
         #endif
       }
     }
 
     #if DEBUG
-      self.init(wrappedValue: elements, outcome: .decodedSuccessfully, results: results)
+    self.init(wrappedValue: elements, outcome: .decodedSuccessfully, results: results)
     #else
-      self.init(wrappedValue: elements, outcome: .decodedSuccessfully)
+    self.init(wrappedValue: elements, outcome: .decodedSuccessfully)
     #endif
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueOmitNilTests.swift
@@ -1,0 +1,66 @@
+//
+//  OptionalDateValueOmitNilTests.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+import KarrotCodableKit
+
+struct OptionalDateValueOmitNilTests {
+  private struct Fixture: Codable {
+    @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
+  }
+
+  @Test
+  func encodingNilOmitsKey() throws {
+    // given
+    let fixture = Fixture(iso8601: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - nil value is omitted, matching Apple's default Codable behavior
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == "{\n\n}")
+  }
+
+  @Test
+  func encodingValuePreservesKey() throws {
+    // given
+    let fixture = Fixture(iso8601: Date(timeIntervalSince1970: 851042397))
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - a present value is still encoded under its key
+    let expectResult = #"""
+    {
+      "iso8601" : "1996-12-20T00:39:57Z"
+    }
+    """#
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == expectResult)
+  }
+
+  @Test
+  func encodingDecodingNilRoundTrip() throws {
+    // given
+    let fixture = Fixture(iso8601: nil)
+
+    // when
+    let data = try JSONEncoder().encode(fixture)
+    let decoded = try JSONDecoder().decode(Fixture.self, from: data)
+
+    // then - nil is restored from the omitted key
+    #expect(decoded.iso8601 == nil)
+  }
+}

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueOmitNilTests.swift
@@ -1,0 +1,68 @@
+//
+//  OptionalLosslessValueOmitNilTests.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+import KarrotCodableKit
+
+struct OptionalLosslessValueOmitNilTests {
+  private struct Fixture: Codable {
+    @OptionalLosslessValue var optionalString: String?
+    @OptionalLosslessValue var optionalInt: Int?
+  }
+
+  @Test
+  func encodingNilOmitsKey() throws {
+    // given
+    let fixture = Fixture(optionalString: nil, optionalInt: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - all nil values are omitted, producing an empty object
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == "{\n\n}")
+  }
+
+  @Test
+  func encodingPartialNilOmitsOnlyNilKeys() throws {
+    // given
+    let fixture = Fixture(optionalString: "hello", optionalInt: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - only optionalInt (nil) is omitted
+    let expectResult = #"""
+    {
+      "optionalString" : "hello"
+    }
+    """#
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == expectResult)
+  }
+
+  @Test
+  func encodingDecodingNilRoundTrip() throws {
+    // given
+    let fixture = Fixture(optionalString: nil, optionalInt: nil)
+
+    // when
+    let data = try JSONEncoder().encode(fixture)
+    let decoded = try JSONDecoder().decode(Fixture.self, from: data)
+
+    // then - nil values are restored from the omitted keys
+    #expect(decoded.optionalString == nil)
+    #expect(decoded.optionalInt == nil)
+  }
+}

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalOmitNilTests.swift
@@ -1,0 +1,68 @@
+//
+//  LossyOptionalOmitNilTests.swift
+//  KarrotCodableKit
+//
+//  Created by Elon on 6/26/26.
+//  Copyright © 2026 Danggeun Market Inc. All rights reserved.
+//
+
+import Foundation
+import Testing
+
+import KarrotCodableKit
+
+struct LossyOptionalOmitNilTests {
+  private struct Fixture: Codable {
+    @LossyOptional var url: URL?
+    @LossyOptional var name: String?
+  }
+
+  @Test
+  func encodingNilOmitsKey() throws {
+    // given
+    let fixture = Fixture(url: nil, name: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - all nil values are omitted, producing an empty object
+    let json = try #require(String(bytes: data, encoding: .utf8))
+    #expect(json == "{\n\n}")
+  }
+
+  @Test
+  func encodingPartialNilOmitsOnlyNilKeys() throws {
+    // given
+    let fixture = Fixture(url: nil, name: "hello")
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(fixture)
+
+    // then - only url (nil) is omitted
+    let expectResult = #"""
+    {
+      "name" : "hello"
+    }
+    """#
+    let json = try #require(String(bytes: data, encoding: .utf8))
+    #expect(json == expectResult)
+  }
+
+  @Test
+  func encodingDecodingNilRoundTrip() throws {
+    // given
+    let fixture = Fixture(url: nil, name: nil)
+
+    // when
+    let data = try JSONEncoder().encode(fixture)
+    let decoded = try JSONDecoder().decode(Fixture.self, from: data)
+
+    // then - nil values are restored from the omitted keys
+    #expect(decoded.url == nil)
+    #expect(decoded.name == nil)
+  }
+}

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
@@ -63,7 +63,7 @@ struct OptionalPolymorphicArrayValueTests {
           title: nil,
           description: "test",
           icon: "test_icon"
-        ),
+        )
       ],
       notices2: nil
     )
@@ -76,8 +76,7 @@ struct OptionalPolymorphicArrayValueTests {
           "icon" : "test_icon",
           "type" : "callout"
         }
-      ],
-      "notices2" : null
+      ]
     }
     """#
 
@@ -86,8 +85,8 @@ struct OptionalPolymorphicArrayValueTests {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(response)
 
-    // then
-    let jsonString = String(decoding: data, as: UTF8.self)
+    // then - notices2 (nil) is omitted, matching Apple's default Codable behavior
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
   }
 
@@ -169,7 +168,7 @@ struct OptionalPolymorphicArrayValueTests {
     {
       "notices1" : {
         "description" : "test",
-        "icon" : "test_icon",  
+        "icon" : "test_icon",
         "type" : "callout"
       }
     }
@@ -194,14 +193,9 @@ struct OptionalPolymorphicArrayValueTests {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(response)
 
-    // then - verify encoded JSON
-    let expectResult = #"""
-    {
-      "notices1" : null,
-      "notices2" : null
-    }
-    """#
-    let jsonString = String(decoding: data, as: UTF8.self)
+    // then - verify encoded JSON (all nil values are omitted, producing an empty object)
+    let expectResult = "{\n\n}"
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
 
     // when - decode back
@@ -210,5 +204,25 @@ struct OptionalPolymorphicArrayValueTests {
     // then - verify decoded values
     #expect(decodedResponse.notices1 == nil)
     #expect(decodedResponse.notices2 == nil)
+  }
+
+  @Test
+  func encodingEmptyArrayIsKeptNotOmitted() throws {
+    // given - an empty array ([]) is non-nil and must be kept, not omitted like nil
+    let response = OptionalPolymorphicArrayDummyResponse(notices1: [], notices2: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let data = try encoder.encode(response)
+
+    // then - notices1 stays as [], only notices2 (nil) is omitted
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == #"{"notices1":[]}"#)
+
+    // round-trip - [] preserved, nil restored
+    let decoded = try JSONDecoder().decode(OptionalPolymorphicArrayDummyResponse.self, from: data)
+    #expect(decoded.notices1?.isEmpty == true)
+    #expect(decoded.notices2 == nil)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
@@ -225,4 +225,25 @@ struct OptionalPolymorphicArrayValueTests {
     #expect(decoded.notices1?.isEmpty == true)
     #expect(decoded.notices2 == nil)
   }
+
+  @Test
+  func encodingNilInUnkeyedContextProducesNull() throws {
+    // given - in an unkeyed container (array element) there is no key to omit,
+    // so a nil wrapper is encoded as an explicit null (matching Apple's `[T?]` behavior)
+    let elements: [DummyNotice.OptionalPolymorphicArray] = [
+      DummyNotice.OptionalPolymorphicArray(wrappedValue: nil)
+    ]
+
+    // when
+    let data = try JSONEncoder().encode(elements)
+
+    // then - the nil element is encoded as null, not omitted
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == "[null]")
+
+    // round-trip - [null] decodes back to a single nil-wrapped element
+    let decoded = try JSONDecoder().decode([DummyNotice.OptionalPolymorphicArray].self, from: data)
+    #expect(decoded.count == 1)
+    #expect(decoded[0].wrappedValue == nil)
+  }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicLossyArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicLossyArrayValueTests.swift
@@ -196,7 +196,7 @@ struct OptionalPolymorphicLossyArrayValueTests {
           title: nil,
           description: "test",
           icon: "test_icon"
-        ),
+        )
       ],
       notices2: nil
     )
@@ -209,8 +209,7 @@ struct OptionalPolymorphicLossyArrayValueTests {
           "icon" : "test_icon",
           "type" : "callout"
         }
-      ],
-      "notices2" : null
+      ]
     }
     """#
 
@@ -219,8 +218,8 @@ struct OptionalPolymorphicLossyArrayValueTests {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(response)
 
-    // then
-    let jsonString = String(decoding: data, as: UTF8.self)
+    // then - notices2 (nil) is omitted, matching Apple's default Codable behavior
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
   }
 
@@ -237,6 +236,10 @@ struct OptionalPolymorphicLossyArrayValueTests {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(response)
 
+    // then - all nil values are omitted, producing an empty object
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == "{\n\n}")
+
     // when - decode back
     let decodedResponse = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
@@ -246,5 +249,25 @@ struct OptionalPolymorphicLossyArrayValueTests {
     // then
     #expect(decodedResponse.notices1 == nil)
     #expect(decodedResponse.notices2 == nil)
+  }
+
+  @Test
+  func encodingEmptyArrayIsKeptNotOmitted() throws {
+    // given - an empty array ([]) is non-nil and must be kept, not omitted like nil
+    let response = OptionalPolymorphicLossyArrayDummyResponse(notices1: [], notices2: nil)
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let data = try encoder.encode(response)
+
+    // then - notices1 stays as [], only notices2 (nil) is omitted
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == #"{"notices1":[]}"#)
+
+    // round-trip - [] preserved, nil restored
+    let decoded = try JSONDecoder().decode(OptionalPolymorphicLossyArrayDummyResponse.self, from: data)
+    #expect(decoded.notices1?.isEmpty == true)
+    #expect(decoded.notices2 == nil)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
@@ -29,8 +29,7 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
         "description" : "test",
         "icon" : "test_icon",
         "type" : "callout"
-      },
-      "notice2" : null
+      }
     }
     """#
 
@@ -39,8 +38,8 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(response)
 
-    // then
-    let jsonString = String(decoding: data, as: UTF8.self)
+    // then - notice2 (nil) is omitted, matching Apple's default Codable behavior
+    let jsonString = try XCTUnwrap(String(bytes: data, encoding: .utf8))
     XCTAssertEqual(jsonString, expectResult)
   }
 
@@ -85,14 +84,9 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(result)
 
-    // then
-    let expectResult = #"""
-    {
-      "notice1" : null,
-      "notice2" : null
-    }
-    """#
-    let jsonString = String(decoding: data, as: UTF8.self)
+    // then - all nil values are omitted, producing an empty object
+    let expectResult = "{\n\n}"
+    let jsonString = try XCTUnwrap(String(bytes: data, encoding: .utf8))
     XCTAssertEqual(jsonString, expectResult)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueTests.swift
@@ -68,4 +68,60 @@ struct OptionalPolymorphicValueTests {
       _ = try JSONDecoder().decode(OptionalDummyResponse.self, from: Data(jsonData.utf8))
     }
   }
+
+  @Test
+  func encodingOptionalPolymorphicValueOmitsNilFields() throws {
+    // given
+    let response = OptionalDummyResponse(
+      notice1: DummyCallout(
+        type: .callout,
+        title: nil,
+        description: "test",
+        icon: "test_icon"
+      ),
+      notice2: nil,
+      notice3: nil
+    )
+
+    // when
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(response)
+
+    // then - nil fields (notice2, notice3) are omitted, matching Apple's default Codable behavior
+    let expectResult = #"""
+    {
+      "notice1" : {
+        "description" : "test",
+        "icon" : "test_icon",
+        "type" : "callout"
+      }
+    }
+    """#
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == expectResult)
+  }
+
+  @Test
+  func encodingDecodingOptionalPolymorphicValueRoundTrip() throws {
+    // given
+    let response = OptionalDummyResponse(notice1: nil, notice2: nil, notice3: nil)
+
+    // when - encode (all nil -> empty object, no explicit null)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(response)
+
+    // then - empty object
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == "{\n\n}")
+
+    // when - decode back
+    let decoded = try JSONDecoder().decode(OptionalDummyResponse.self, from: data)
+
+    // then - nil values are restored (round-trip)
+    #expect(decoded.notice1 == nil)
+    #expect(decoded.notice2 == nil)
+    #expect(decoded.notice3 == nil)
+  }
 }


### PR DESCRIPTION
## Overview
Changes the encoding behavior of Optional property wrappers/macros so that a `nil` value **omits the key entirely**, matching Apple's default `Codable` behavior — instead of writing an explicit `null` via `encodeNil()`.

## Background
Swift's synthesized `Codable` omits the key for `nil` optional properties (via `encodeIfPresent`). KarrotCodableKit's Optional wrappers instead emitted an explicit `null` through `singleValueContainer().encodeNil()`, diverging from that behavior.

> Note: simply removing the `encodeNil()` call inside a wrapper's `encode(to:)` does **not** omit the key — it leaves an empty object `{}` behind. Key omission can only be decided at the parent container level, i.e. whether `encode(_:forKey:)` is invoked at all.

## Changes
Each Optional wrapper gains a `KeyedEncodingContainer.encode(_:forKey:)` overload that skips the key when `wrappedValue == nil`. This is exactly symmetric with the existing `decode(_:forKey:)` overload (`contains(key)` check). Macros (`@CustomCodable` synthesis / `@UnnestedPolymorphic`) call this container overload automatically, so no macro changes are required.

Covered **7 wrappers** (split into one commit per wrapper):
- OptionalPolymorphicValue
- LossyOptionalPolymorphicValue
- OptionalPolymorphicArrayValue
- OptionalPolymorphicLossyArrayValue
- OptionalDateValue
- OptionalLosslessValue
- LossyOptional — constrained to `DefaultCodable<DefaultNilStrategy>` so other `DefaultCodable` wrappers (`@DefaultFalse`, `@DefaultEmptyArray`, ...) are unaffected

## Behavior
- `nil` → key omitted
- present value → encoded as before
- empty array `[]` → preserved (distinct from nil)
- unkeyed context (array element) → still `null` (same as Apple's `[T?]`)
- round-trip: omitted key → keyNotFound on decode → restored to `nil`

## ⚠️ Breaking Change
Encoded output now **omits the key** for `nil` optional fields instead of writing `"key": null`. Consumers that distinguish explicit null from key absence (e.g. PATCH semantics where null = "delete field") may be affected.

## Tests
- Debug: XCTest 194 + swift-testing 165, 0 failures
- Release: XCTest 194 + swift-testing 162, 0 failures
- Added per-wrapper nil-omission + round-trip tests, plus empty-array (`[]`) preservation regression tests

https://claude.ai/code/session_01BSXaRrJaLrjWQaiJSMy45Q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional values in JSON encoding now omit missing fields instead of writing `null` for several supported value types.
  * Added coverage for polymorphic arrays, lossy arrays, polymorphic values, lossless values, and dates.

* **Bug Fixes**
  * Improved round-trip behavior so omitted fields decode back to `nil` correctly.
  * Preserved empty arrays during encoding while still omitting missing values.

* **Tests**
  * Added and updated tests to verify empty-object output, field omission, and encoding/decoding consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->