### PR TITLE
chore(concurrency): 라이브러리를 Swift 6 language mode 에서 빌드되게 + CI 게이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,15 @@ jobs:
 
       - name: Run Swift Macro Compatibility Check
         uses: Matejkob/swift-macro-compatibility-check@v1
+
+  swift6-mode:
+    name: Swift 6 Language Mode
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+
+      - name: Build in Swift 6 language mode
+        run: swift build -Xswiftc -swift-version -Xswiftc 6

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601WithFractionalSecondsStrategy.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601WithFractionalSecondsStrategy.swift
@@ -16,7 +16,9 @@ import Foundation
 /// representing 39 minutes and 57 seconds after the 16th hour of December 19th, 1996 with an offset of -08:00 from UTC
 /// (Pacific Standard Time).
 public struct ISO8601WithFractionalSecondsStrategy: DateValueCodableStrategy {
-  private static let formatter: ISO8601DateFormatter = {
+  // `ISO8601DateFormatter` is configured once and never mutated, so concurrent reads are safe.
+  // `nonisolated(unsafe)` acknowledges this until the SDK annotates the type `Sendable`.
+  private nonisolated(unsafe) static let formatter: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return formatter

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessValue.swift
@@ -101,7 +101,8 @@ extension LosslessValueCodable: Hashable where Strategy.Value: Hashable {
   }
 }
 
-extension LosslessValueCodable: Sendable where Strategy.Value: Sendable {}
+// `type` is an immutable metatype (no shared mutable state); the where-clause keeps `wrappedValue` safe.
+extension LosslessValueCodable: @unchecked Sendable where Strategy.Value: Sendable {}
 
 public struct LosslessDefaultStrategy<Value: LosslessStringCodable>: LosslessDecodingStrategy {
   public static var losslessDecodableTypes: [(Decoder) -> LosslessStringCodable?] {

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/OptionalLosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/OptionalLosslessValue.swift
@@ -120,7 +120,8 @@ extension OptionalLosslessValueCodable: Hashable where Strategy.Value: Hashable 
   }
 }
 
-extension OptionalLosslessValueCodable: Sendable where Strategy.Value: Sendable {}
+// `type` is an immutable metatype (no shared mutable state); the where-clause keeps `wrappedValue` safe.
+extension OptionalLosslessValueCodable: @unchecked Sendable where Strategy.Value: Sendable {}
 
 /// Decodes Optional Codable values into their respective preferred types.
 ///

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Error/PolymorphicCodableError.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Error/PolymorphicCodableError.swift
@@ -34,3 +34,6 @@ public enum PolymorphicCodableError: LocalizedError {
     }
   }
 }
+
+// Immutable error value; the `decoded` payload is only read for diagnostics.
+extension PolymorphicCodableError: @unchecked Sendable {}

--- a/Sources/KarrotCodableKit/Resilient/ArrayDecodingError.swift
+++ b/Sources/KarrotCodableKit/Resilient/ArrayDecodingError.swift
@@ -40,3 +40,8 @@ extension ResilientDecodingOutcome {
   }
 }
 #endif
+
+#if DEBUG
+// DEBUG-only immutable diagnostic holder; `results` is read-only after init.
+extension ResilientDecodingOutcome.ArrayDecodingError: @unchecked Sendable {}
+#endif

--- a/Sources/KarrotCodableKit/Resilient/DictionaryDecodingError.swift
+++ b/Sources/KarrotCodableKit/Resilient/DictionaryDecodingError.swift
@@ -38,3 +38,8 @@ extension ResilientDecodingOutcome {
   }
 }
 #endif
+
+#if DEBUG
+// DEBUG-only immutable diagnostic holder; `results` is read-only after init.
+extension ResilientDecodingOutcome.DictionaryDecodingError: @unchecked Sendable {}
+#endif

--- a/Sources/KarrotCodableKit/Resilient/ErrorReporting.swift
+++ b/Sources/KarrotCodableKit/Resilient/ErrorReporting.swift
@@ -236,3 +236,6 @@ public struct UnknownNovelValueError: Error {
     self.novelValue = novelValue
   }
 }
+
+// Immutable; `novelValue` is captured once and only read for diagnostics.
+extension UnknownNovelValueError: @unchecked Sendable {}

--- a/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicCodableMacro.swift
@@ -12,8 +12,8 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 public enum UnnestedPolymorphicCodableMacro: MemberMacro, UnnestedPolymorphicMacroType {
-  public static let protocolType = PolymorphicExtensionFactory.PolymorphicProtocolType.codable
-  public static let macroType = UnnestedPolymorphicCodeGenerator.MacroType.codable
+  public nonisolated(unsafe) static let protocolType = PolymorphicExtensionFactory.PolymorphicProtocolType.codable
+  public nonisolated(unsafe) static let macroType = UnnestedPolymorphicCodeGenerator.MacroType.codable
   public static let macroName = "UnnestedPolymorphicCodable"
 
   public static func expansion(

--- a/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicDecodableMacro.swift
@@ -12,8 +12,8 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 public enum UnnestedPolymorphicDecodableMacro: MemberMacro, UnnestedPolymorphicMacroType {
-  public static let protocolType = PolymorphicExtensionFactory.PolymorphicProtocolType.decodable
-  public static let macroType = UnnestedPolymorphicCodeGenerator.MacroType.decodable
+  public nonisolated(unsafe) static let protocolType = PolymorphicExtensionFactory.PolymorphicProtocolType.decodable
+  public nonisolated(unsafe) static let macroType = UnnestedPolymorphicCodeGenerator.MacroType.decodable
   public static let macroName = "UnnestedPolymorphicDecodable"
 
   public static func expansion(


### PR DESCRIPTION
## 배경

라이브러리가 **Swift 6 language mode 에서 컴파일되지 않았습니다.** 다음이 비-`Sendable` 공유/전역 상태에서 실패합니다.

```bash
swift build -Xswiftc -swift-version -Xswiftc 6   # ← 에러로 실패
```

## 왜 -strict-concurrency=complete 로는 부족한가

처음엔 Swift 5 모드의 `-strict-concurrency=complete` 로 범위를 재려 했으나, 이는 **근사치**였습니다. 진짜 Swift 6 모드는 정적 전역(`#MutableGlobalVariable`)을 **하드 에러**로 처리하고 그 지점에서 **빌드를 조기 중단**해 하위 파일의 문제를 가립니다.

```text
-strict-concurrency=complete (Swift 5 모드)     -swift-version 6 (Swift 6 모드)
  = 경고로 나열, 끝까지 진행                        = 에러, 첫 하드에러에서 중단
        │                                                 │
        └── 근사치(과소/과대 가능)                         └── 정본: "빌드 성공(exit 0)" 이 유일한 준비도 증거
```

그래서 **정본 기준을 `-swift-version 6` 빌드 성공(exit 0)** 으로 잡고, 매크로 타깃 정적부터 고쳐 라이브러리 에러가 드러나게 한 뒤 전부 해소했습니다.

## 변경사항

```text
컴파일러로 범위 측정 ── swift build -swift-version 6
        │
   ┌────┴───────────────────────────────────┐
   ▼                                         ▼
정적 공유 상태                        불변 값/메타타입/에러 홀더
nonisolated(unsafe)                   @unchecked Sendable
   └────┬───────────────────────────────────┘
        ▼
 swift build -swift-version 6 ──(exit 0)──▶ CI 게이트 통과
```

| 대상 | 처리 | 근거 |
|---|---|---|
| static `ISO8601DateFormatter` | `nonisolated(unsafe)` | 1회 설정 후 불변, 동시 읽기 안전 |
| 매크로 `protocolType` / `macroType` | `nonisolated(unsafe)` | 컴파일타임 상수 서술자 |
| `LosslessValueCodable` / `OptionalLosslessValueCodable` | `@unchecked Sendable` (조건부) | `type` 은 불변 메타타입; `where Strategy.Value: Sendable` 유지 |
| `PolymorphicCodableError` | `@unchecked Sendable` | 불변 에러 값 |
| `ArrayDecodingError` / `DictionaryDecodingError` | `@unchecked Sendable` (DEBUG 전용) | 불변 진단 홀더 |
| `UnknownNovelValueError` | `@unchecked Sendable` | `novelValue` 는 1회 캡처 후 읽기 전용 |

```swift
// 예시 1) 정적 포매터
- private static let formatter: ISO8601DateFormatter = { … }()
+ private nonisolated(unsafe) static let formatter: ISO8601DateFormatter = { … }()

// 예시 2) 조건부 Sendable 은 제약을 유지한 채 @unchecked 로
- extension LosslessValueCodable: Sendable where Strategy.Value: Sendable {}
+ extension LosslessValueCodable: @unchecked Sendable where Strategy.Value: Sendable {}

// 예시 3) 불변 에러/진단 홀더
+ extension PolymorphicCodableError: @unchecked Sendable {}
+ #if DEBUG
+ extension ResilientDecodingOutcome.ArrayDecodingError: @unchecked Sendable {}
+ #endif
```

또 회귀 방지를 위해 CI 잡을 추가했습니다.

```yaml
  swift6-mode:
    name: Swift 6 Language Mode
    runs-on: macos-15
    steps:
      - uses: actions/checkout@v4
      - name: Select Xcode 16.4
        run: sudo xcode-select -s /Applications/Xcode_16.4.app
      - name: Build in Swift 6 language mode
        run: swift build -Xswiftc -swift-version -Xswiftc 6
```

## 변경 파일

- **소스(7)**: `ISO8601WithFractionalSecondsStrategy.swift`, `LosslessValue.swift`, `OptionalLosslessValue.swift`, `PolymorphicCodableError.swift`, `ArrayDecodingError.swift`, `DictionaryDecodingError.swift`, `ErrorReporting.swift`
- **매크로(2)**: `UnnestedPolymorphicCodableMacro.swift`, `UnnestedPolymorphicDecodableMacro.swift`
- **CI(1)**: `.github/workflows/ci.yml`

_10 files changed, +40 / −8_

## 변경했을 때의 트레이드 오프

- `@unchecked Sendable` / `nonisolated(unsafe)` 는 **컴파일러 검사 우회 + 개발자 보증**입니다. 대상이 전부 `init` 후 불변이라 안전하지만, 향후 이 타입들에 가변 상태가 추가되면 보증이 깨질 수 있어 각 지점에 근거 주석을 남겼습니다.
- **`Package.swift` 에 `StrictConcurrency` 를 켜지 않았습니다.** 켜면 "기타"의 양성 warning 1건이 모든 기여자의 일반 빌드에 상시 노출됩니다. 대신 일반 빌드는 깨끗하게 두고, 회귀는 **CI 의 `-swift-version 6` 게이트**로 잡습니다. (트레이드: 로컬에서 즉시 strict 피드백은 못 받음)
- **swift-tools 5.9 유지** → 소비자 하위 호환 최대. 단 이 PR 의 목표는 "Swift 6 로 **빌드 가능**" 이지 "패키지를 Swift 6 언어 모드로 **채택**(tools 6.0 상향)" 은 아닙니다.

## 테스트 방법

- `swift build -Xswiftc -swift-version -Xswiftc 6` → **exit 0** (정본 준비도 게이트, CI 에서 강제).
- `swift test -c debug` / `swift test -c release` — 전부 통과(실패 0), 런타임 동작 변화 없음.

## 기타

- 이 툴체인(**macOS 26 SDK**)에서 컴파일러가 **플래그하지 않아 그대로 둔 항목**: `ResilientDecodingOutcome.recoveredFrom(any Error)`, 그리고 `RFC3339` / `RFC3339Nano` 의 static `DateFormatter`. (SDK 가 `DateFormatter` 는 이미 `Sendable` 로 표기했고, `ISO8601DateFormatter` 만 아직 아님.)
- `-strict-concurrency=complete` 에서만 남는 **양성 진단 1건**: `Resilient/ErrorReporting.swift:68` — airbnb 유래 에러 리포터 왕복의 `Any`. Swift 6 language mode 에서도 warning 이며 Swift 6 빌드를 막지 않습니다.
- **범위 외(후속 후보)**: `MemberMacro` deprecated API 경고 ~78건, `validateFallbackCaseName` unused-result 경고 몇 건.

