### PR TITLE
test: 런타임 테스트를 XCTest 에서 swift-testing 으로 마이그레이션

### DIFF
--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyCodableTests.swift
@@ -5,10 +5,11 @@
 //  Created by Elon on 4/9/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import KarrotCodableKit
 
-final class AnyCodableTests: XCTestCase {
+struct AnyCodableTests {
 
   @CustomCodable(codingKeyStyle: .snakeCase)
   struct SomeCodable {
@@ -18,7 +19,7 @@ final class AnyCodableTests: XCTestCase {
     var hasUnderscore: String
   }
 
-  func testJSONDecoding() throws {
+  @Test func testJSONDecoding() throws {
     // given
     let json = """
       {
@@ -41,16 +42,16 @@ final class AnyCodableTests: XCTestCase {
     let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
 
     // then
-    XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-    XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-    XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
-    XCTAssertEqual(dictionary["string"]?.value as! String, "string")
-    XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
-    XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
-    XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+    #expect(dictionary["boolean"]?.value as! Bool == true)
+    #expect(dictionary["integer"]?.value as! Int == 42)
+    #expect(abs(dictionary["double"]?.value as! Double - 3.141592653589793) < 0.001)
+    #expect(dictionary["string"]?.value as! String == "string")
+    #expect(dictionary["array"]?.value as! [Int] == [1, 2, 3])
+    #expect(dictionary["nested"]?.value as! [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
+    #expect(dictionary["null"]?.value as! NSNull == NSNull())
   }
 
-  func testJSONDecodingEquatable() throws {
+  @Test func testJSONDecodingEquatable() throws {
     // given
     let json = """
       {
@@ -74,16 +75,16 @@ final class AnyCodableTests: XCTestCase {
     let dictionary2 = try decoder.decode([String: AnyCodable].self, from: json)
 
     // then
-    XCTAssertEqual(dictionary1["boolean"], dictionary2["boolean"])
-    XCTAssertEqual(dictionary1["integer"], dictionary2["integer"])
-    XCTAssertEqual(dictionary1["double"], dictionary2["double"])
-    XCTAssertEqual(dictionary1["string"], dictionary2["string"])
-    XCTAssertEqual(dictionary1["array"], dictionary2["array"])
-    XCTAssertEqual(dictionary1["nested"], dictionary2["nested"])
-    XCTAssertEqual(dictionary1["null"], dictionary2["null"])
+    #expect(dictionary1["boolean"] == dictionary2["boolean"])
+    #expect(dictionary1["integer"] == dictionary2["integer"])
+    #expect(dictionary1["double"] == dictionary2["double"])
+    #expect(dictionary1["string"] == dictionary2["string"])
+    #expect(dictionary1["array"] == dictionary2["array"])
+    #expect(dictionary1["nested"] == dictionary2["nested"])
+    #expect(dictionary1["null"] == dictionary2["null"])
   }
 
-  func testJSONEncoding() throws {
+  @Test func testJSONEncoding() throws {
     // given
     let someCodable = AnyCodable(SomeCodable(
       string: "String",
@@ -139,6 +140,6 @@ final class AnyCodableTests: XCTestCase {
       """.data(using: .utf8)!
     let expectedJSONObject = try JSONSerialization.jsonObject(with: expected) as! NSDictionary
 
-    XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    #expect(encodedJSONObject == expectedJSONObject)
   }
 }

--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyDecodableTests.swift
@@ -5,11 +5,12 @@
 //  Created by Elon on 4/9/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import KarrotCodableKit
 
-final class AnyDecodableTests: XCTestCase {
-  func testJSONDecoding() throws {
+struct AnyDecodableTests {
+  @Test func testJSONDecoding() throws {
     // given
     let json = """
       {
@@ -32,12 +33,12 @@ final class AnyDecodableTests: XCTestCase {
     let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
 
     // then
-    XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
-    XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-    XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
-    XCTAssertEqual(dictionary["string"]?.value as! String, "string")
-    XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
-    XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
-    XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+    #expect(dictionary["boolean"]?.value as! Bool == true)
+    #expect(dictionary["integer"]?.value as! Int == 42)
+    #expect(abs(dictionary["double"]?.value as! Double - 3.141592653589793) < 0.001)
+    #expect(dictionary["string"]?.value as! String == "string")
+    #expect(dictionary["array"]?.value as! [Int] == [1, 2, 3])
+    #expect(dictionary["nested"]?.value as! [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
+    #expect(dictionary["null"]?.value as! NSNull == NSNull())
   }
 }

--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyEncodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyEncodableTests.swift
@@ -5,10 +5,11 @@
 //  Created by Elon on 4/9/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import KarrotCodableKit
 
-final class AnyEncodableTests: XCTestCase {
+struct AnyEncodableTests {
 
   @CustomEncodable(codingKeyStyle: .snakeCase)
   struct SomeEncodable {
@@ -18,7 +19,7 @@ final class AnyEncodableTests: XCTestCase {
     var hasUnderscore: String
   }
 
-  func testJSONEncoding() throws {
+  @Test func testJSONEncoding() throws {
     // given
     let someEncodable = AnyEncodable(SomeEncodable(
       string: "String",
@@ -71,10 +72,10 @@ final class AnyEncodableTests: XCTestCase {
       """.data(using: .utf8)!
     let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
 
-    XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    #expect(encodedJSONObject == expectedJSONObject)
   }
 
-  func testEncodeNSNumber() throws {
+  @Test func testEncodeNSNumber() throws {
     // given
     let dictionary: [String: NSNumber] = [
       "boolean": true,
@@ -115,25 +116,25 @@ final class AnyEncodableTests: XCTestCase {
       """.data(using: .utf8)!
     let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
 
-    XCTAssertEqual(encodedJSONObject, expectedJSONObject)
-    XCTAssert(encodedJSONObject["boolean"] is Bool)
+    #expect(encodedJSONObject == expectedJSONObject)
+    #expect(encodedJSONObject["boolean"] is Bool)
 
-    XCTAssert(encodedJSONObject["char"] is Int8)
-    XCTAssert(encodedJSONObject["int"] is Int16)
-    XCTAssert(encodedJSONObject["short"] is Int32)
-    XCTAssert(encodedJSONObject["long"] is Int32)
-    XCTAssert(encodedJSONObject["longlong"] is Int64)
+    #expect(encodedJSONObject["char"] is Int8)
+    #expect(encodedJSONObject["int"] is Int16)
+    #expect(encodedJSONObject["short"] is Int32)
+    #expect(encodedJSONObject["long"] is Int32)
+    #expect(encodedJSONObject["longlong"] is Int64)
 
-    XCTAssert(encodedJSONObject["uchar"] is UInt8)
-    XCTAssert(encodedJSONObject["uint"] is UInt16)
-    XCTAssert(encodedJSONObject["ushort"] is UInt32)
-    XCTAssert(encodedJSONObject["ulong"] is UInt32)
-    XCTAssert(encodedJSONObject["ulonglong"] is UInt64)
+    #expect(encodedJSONObject["uchar"] is UInt8)
+    #expect(encodedJSONObject["uint"] is UInt16)
+    #expect(encodedJSONObject["ushort"] is UInt32)
+    #expect(encodedJSONObject["ulong"] is UInt32)
+    #expect(encodedJSONObject["ulonglong"] is UInt64)
 
-    XCTAssert(encodedJSONObject["double"] is Double)
+    #expect(encodedJSONObject["double"] is Double)
   }
 
-  func testStringInterpolationEncoding() throws {
+  @Test func testStringInterpolationEncoding() throws {
     // given
     let dictionary: [String: AnyEncodable] = [
       "boolean": "\(true)",
@@ -160,6 +161,6 @@ final class AnyEncodableTests: XCTestCase {
       """.data(using: .utf8)!
     let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
 
-    XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    #expect(encodedJSONObject == expectedJSONObject)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueTests.swift
@@ -5,12 +5,13 @@
 //  Created by Elon on 4/9/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DataValueTests: XCTestCase {
-  func testDecodingAndEncodingBase64String() throws {
+struct DataValueTests {
+  @Test func testDecodingAndEncodingBase64String() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: Data
@@ -21,16 +22,16 @@ final class DataValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.data, Data("BetterCodable".utf8))
+    #expect(fixture.data == Data("BetterCodable".utf8))
 
     // when
     let outputJSON = try JSONEncoder().encode(fixture)
 
     // then
-    XCTAssertEqual(outputJSON, jsonData)
+    #expect(outputJSON == jsonData)
   }
 
-  func testDecodingMalformedBase64Fails() throws {
+  @Test func testDecodingMalformedBase64Fails() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: Data
@@ -38,10 +39,10 @@ final class DataValueTests: XCTestCase {
     let jsonData = #"{"data":"invalidBase64!"}"#.data(using: .utf8)!
 
     // when & then
-    XCTAssertThrowsError(try JSONDecoder().decode(Fixture.self, from: jsonData))
+    #expect(throws: (any Error).self) { try JSONDecoder().decode(Fixture.self, from: jsonData) }
   }
 
-  func testDecodingAndEncodingBase64StringToArray() throws {
+  @Test func testDecodingAndEncodingBase64StringToArray() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: [UInt8]
@@ -52,12 +53,12 @@ final class DataValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.data, Array("BetterCodable".utf8))
+    #expect(fixture.data == Array("BetterCodable".utf8))
 
     // when
     let outputJSON = try JSONEncoder().encode(fixture)
 
     // then
-    XCTAssertEqual(outputJSON, jsonData)
+    #expect(outputJSON == jsonData)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueTests.swift
@@ -5,12 +5,13 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DateValueTests: XCTestCase {
-  func testDecodingAndEncodingISO8601DateString() throws {
+struct DateValueTests {
+  @Test func testDecodingAndEncodingISO8601DateString() throws {
     struct Fixture: Codable {
       @DateValue<ISO8601Strategy> var iso8601: Date
     }
@@ -22,10 +23,10 @@ final class DateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.iso8601, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
+  @Test func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
     struct Fixture: Codable {
       @DateValue<ISO8601WithFractionalSecondsStrategy> var iso8601: Date
       @DateValue<ISO8601WithFractionalSecondsStrategy> var iso8601Short: Date
@@ -43,11 +44,11 @@ final class DateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.iso8601Short, Date(timeIntervalSince1970: 851042397.0))
-    XCTAssertEqual(fixture.iso8601, Date(timeIntervalSince1970: 851013597.123))
+    #expect(fixture.iso8601Short == Date(timeIntervalSince1970: 851042397.0))
+    #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851013597.123))
   }
 
-  func testDecodingAndEncodingRFC3339DateString() throws {
+  @Test func testDecodingAndEncodingRFC3339DateString() throws {
     struct Fixture: Codable {
       @DateValue<RFC3339Strategy> var rfc3339Date: Date
     }
@@ -59,10 +60,10 @@ final class DateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.rfc3339Date, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.rfc3339Date == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingRFC3339NanoDateString() throws {
+  @Test func testDecodingRFC3339NanoDateString() throws {
     struct Fixture: Codable {
       @DateValue<RFC3339NanoStrategy> var rfc3339Date1: Date
       @DateValue<RFC3339NanoStrategy> var rfc3339Date2: Date
@@ -88,15 +89,15 @@ final class DateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.rfc3339Date1, Date(timeIntervalSince1970: 851042397.0))
-    XCTAssertEqual(fixture.rfc3339Date2, Date(timeIntervalSince1970: 851042397.0))
-    XCTAssertEqual(fixture.rfc3339Date3, Date(timeIntervalSince1970: 1720617749.481))
-    XCTAssertEqual(fixture.rfc3339Date4, Date(timeIntervalSince1970: 1720588949.481))
-    XCTAssertEqual(fixture.rfc3339Date5, Date(timeIntervalSince1970: 1715082540.000))
-    XCTAssertEqual(fixture.rfc3339Date6, Date(timeIntervalSince1970: 1715082540.000))
+    #expect(fixture.rfc3339Date1 == Date(timeIntervalSince1970: 851042397.0))
+    #expect(fixture.rfc3339Date2 == Date(timeIntervalSince1970: 851042397.0))
+    #expect(fixture.rfc3339Date3 == Date(timeIntervalSince1970: 1720617749.481))
+    #expect(fixture.rfc3339Date4 == Date(timeIntervalSince1970: 1720588949.481))
+    #expect(fixture.rfc3339Date5 == Date(timeIntervalSince1970: 1715082540.000))
+    #expect(fixture.rfc3339Date6 == Date(timeIntervalSince1970: 1715082540.000))
   }
 
-  func testEncodingRFC3339NanoDateToString() throws {
+  @Test func testEncodingRFC3339NanoDateToString() throws {
     // given
     let date = Date(timeIntervalSince1970: 1720588949.481)
 
@@ -104,20 +105,20 @@ final class DateValueTests: XCTestCase {
     let result = RFC3339NanoStrategy.encode(date)
 
     // then
-    XCTAssertEqual(result, "2024-07-10T05:22:29.481000Z")
+    #expect(result == "2024-07-10T05:22:29.481000Z")
   }
 
-  func testDecodingAndEncodingUTCTimestamp() throws {
+  @Test func testDecodingAndEncodingUTCTimestamp() throws {
     struct Fixture: Codable {
       @DateValue<TimestampStrategy> var timestamp: Date
     }
     let jsonData = #"{"timestamp": 851042397.0}"#.data(using: .utf8)!
 
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
-    XCTAssertEqual(fixture.timestamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.timestamp == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingAndEncodingWithCustomStrategies() throws {
+  @Test func testDecodingAndEncodingWithCustomStrategies() throws {
     struct Fixture: Codable {
       @DateValue<TimestampStrategy> var timeStamp: Date
     }
@@ -127,13 +128,13 @@ final class DateValueTests: XCTestCase {
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     decoder.dateDecodingStrategy = .iso8601
     let fixture = try decoder.decode(Fixture.self, from: jsonData)
-    XCTAssertEqual(fixture.timeStamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.timeStamp == Date(timeIntervalSince1970: 851042397))
 
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     encoder.dateEncodingStrategy = .iso8601
     let data = try encoder.encode(fixture)
     let fixture2 = try decoder.decode(Fixture.self, from: data)
-    XCTAssertEqual(fixture2.timeStamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture2.timeStamp == Date(timeIntervalSince1970: 851042397))
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2024 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class OptionalDateValueTests: XCTestCase {
+struct OptionalDateValueTests {
 
-  func testDecodingAndEncodingISO8601DateString() throws {
+  @Test func testDecodingAndEncodingISO8601DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -24,10 +25,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.iso8601, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingAndEncodingOptionalISO8601DateString() throws {
+  @Test func testDecodingAndEncodingOptionalISO8601DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -39,10 +40,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.iso8601)
+    #expect(fixture.iso8601 == nil)
   }
 
-  func testDecodingAndEncodingNotPresentISO8601DateString() throws {
+  @Test func testDecodingAndEncodingNotPresentISO8601DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -54,10 +55,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.iso8601)
+    #expect(fixture.iso8601 == nil)
   }
 
-  func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
+  @Test func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601WithFractionalSecondsStrategy> var iso8601: Date?
       @OptionalDateValue<ISO8601WithFractionalSecondsStrategy> var iso8601Short: Date?
@@ -75,11 +76,11 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.iso8601Short, Date(timeIntervalSince1970: 851013597.0))
-    XCTAssertEqual(fixture.iso8601, Date(timeIntervalSince1970: 851013597.123))
+    #expect(fixture.iso8601Short == Date(timeIntervalSince1970: 851013597.0))
+    #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851013597.123))
   }
 
-  func testDecodingAndEncodingRFC3339DateString() throws {
+  @Test func testDecodingAndEncodingRFC3339DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -91,10 +92,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.rfc3339Date, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.rfc3339Date == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingAndEncodingOptionalRFC3339DateString() throws {
+  @Test func testDecodingAndEncodingOptionalRFC3339DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -106,10 +107,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.rfc3339Date)
+    #expect(fixture.rfc3339Date == nil)
   }
 
-  func testDecodingAndEncodingNotPresentRFC3339DateString() throws {
+  @Test func testDecodingAndEncodingNotPresentRFC3339DateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -121,10 +122,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.rfc3339Date)
+    #expect(fixture.rfc3339Date == nil)
   }
 
-  func testDecodingRFC3339NanoDateString() throws {
+  @Test func testDecodingRFC3339NanoDateString() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339NanoStrategy> var rfc3339Date1: Date?
       @OptionalDateValue<RFC3339NanoStrategy> var rfc3339Date2: Date?
@@ -150,15 +151,15 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.rfc3339Date1, Date(timeIntervalSince1970: 851042397.0))
-    XCTAssertEqual(fixture.rfc3339Date2, Date(timeIntervalSince1970: 851042397.0))
-    XCTAssertEqual(fixture.rfc3339Date3, Date(timeIntervalSince1970: 1720617749.481))
-    XCTAssertEqual(fixture.rfc3339Date4, Date(timeIntervalSince1970: 1720588949.481))
-    XCTAssertEqual(fixture.rfc3339Date5, Date(timeIntervalSince1970: 1715082540.000))
-    XCTAssertEqual(fixture.rfc3339Date6, Date(timeIntervalSince1970: 1715082540.000))
+    #expect(fixture.rfc3339Date1 == Date(timeIntervalSince1970: 851042397.0))
+    #expect(fixture.rfc3339Date2 == Date(timeIntervalSince1970: 851042397.0))
+    #expect(fixture.rfc3339Date3 == Date(timeIntervalSince1970: 1720617749.481))
+    #expect(fixture.rfc3339Date4 == Date(timeIntervalSince1970: 1720588949.481))
+    #expect(fixture.rfc3339Date5 == Date(timeIntervalSince1970: 1715082540.000))
+    #expect(fixture.rfc3339Date6 == Date(timeIntervalSince1970: 1715082540.000))
   }
 
-  func testDecodingAndEncodingUTCTimestamp() throws {
+  @Test func testDecodingAndEncodingUTCTimestamp() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timestamp: Date?
     }
@@ -170,10 +171,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.timestamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.timestamp == Date(timeIntervalSince1970: 851042397))
   }
 
-  func testDecodingAndEncodingOptionalUTCTimestamp() throws {
+  @Test func testDecodingAndEncodingOptionalUTCTimestamp() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timestamp: Date?
     }
@@ -185,10 +186,10 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.timestamp)
+    #expect(fixture.timestamp == nil)
   }
 
-  func testDecodingAndEncodingWithCustomStrategies() throws {
+  @Test func testDecodingAndEncodingWithCustomStrategies() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timeStamp: Date?
     }
@@ -203,7 +204,7 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture = try decoder.decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.timeStamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture.timeStamp == Date(timeIntervalSince1970: 851042397))
 
     // when
     let encoder = JSONEncoder()
@@ -213,6 +214,6 @@ final class OptionalDateValueTests: XCTestCase {
     let fixture2 = try decoder.decode(Fixture.self, from: data)
 
     // then
-    XCTAssertEqual(fixture2.timeStamp, Date(timeIntervalSince1970: 851042397))
+    #expect(fixture2.timeStamp == Date(timeIntervalSince1970: 851042397))
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaulEmptyDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaulEmptyDictionaryTests.swift
@@ -5,16 +5,17 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultEmptyDictionaryTests: XCTestCase {
+struct DefaultEmptyDictionaryTests {
   struct Fixture: Equatable, Codable {
     @DefaultEmptyDictionary var stringToInt: [String: Int]
   }
 
-  func testDecodingFailableDictionaryDefaultsToEmptyDictionary() throws {
+  @Test func testDecodingFailableDictionaryDefaultsToEmptyDictionary() throws {
     // given
     let jsonData = #"{ "stringToInt": null }"#.data(using: .utf8)!
 
@@ -22,10 +23,10 @@ final class DefaultEmptyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, [:])
+    #expect(fixture.stringToInt == [:])
   }
 
-  func testDecodingKeyNotPresentDefaultsToEmptyDictionary() throws {
+  @Test func testDecodingKeyNotPresentDefaultsToEmptyDictionary() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -33,10 +34,10 @@ final class DefaultEmptyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, [:])
+    #expect(fixture.stringToInt == [:])
   }
 
-  func testEncodingDecodedFailableDictionaryDefaultsToEmptyDictionary() throws {
+  @Test func testEncodingDecodedFailableDictionaryDefaultsToEmptyDictionary() throws {
     // given
     let jsonData = #"{ "stringToInt": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -47,10 +48,10 @@ final class DefaultEmptyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, ["one": 1])
+    #expect(fixture.stringToInt == ["one": 1])
   }
 
-  func testEncodingDecodedFulfillableDictionaryRetainsContents() throws {
+  @Test func testEncodingDecodedFulfillableDictionaryRetainsContents() throws {
     // given
     let jsonData = #"{ "stringToInt": {"one": 1, "two": 2} }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -60,6 +61,6 @@ final class DefaultEmptyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, ["one": 1, "two": 2])
+    #expect(fixture.stringToInt == ["one": 1, "two": 2])
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableTests.swift
@@ -5,7 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
@@ -41,27 +42,27 @@ extension JSONEncoder {
   }
 }
 
-final class DefaultCodableTest_DateStrategy: XCTestCase {
+struct DefaultCodableTest_DateStrategy {
   struct Fixture: Equatable, Codable {
     @DefaultCodable<Date.DefaultToNow>
     fileprivate var discoverDate: Date
   }
 
-  func testDecodingAndEncodingWithDateStrategy() throws {
+  @Test func testDecodingAndEncodingWithDateStrategy() throws {
     let expectedDate = Date(timeIntervalSinceReferenceDate: 222601260)
     let jsonData = #"{ "discoverDate": "2008-01-21T09:41:00.000Z" }"#.data(using: .utf8)!
     let fixture = try JSONDecoder.iso.decode(Fixture.self, from: jsonData)
-    XCTAssertEqual(fixture.discoverDate, expectedDate)
+    #expect(fixture.discoverDate == expectedDate)
 
     let data = try JSONEncoder.iso.encode(fixture)
     let str = String(data: data, encoding: .utf8)
-    XCTAssertEqual(str, #"{"discoverDate":"2008-01-21T09:41:00.000Z"}"#)
+    #expect(str == #"{"discoverDate":"2008-01-21T09:41:00.000Z"}"#)
   }
 }
 
 // MARK: - Nested Property Wrapper
 
-final class DefaultCodableTest_NestedPropertyWrapper: XCTestCase {
+struct DefaultCodableTest_NestedPropertyWrapper {
   enum DefaultToNowTimeStampDateValue: DefaultCodableStrategy {
     static var defaultValue: DateValue<TimestampStrategy> {
       .init(wrappedValue: Date(timeIntervalSince1970: 0))
@@ -74,7 +75,7 @@ final class DefaultCodableTest_NestedPropertyWrapper: XCTestCase {
     var returnDate: Date
   }
 
-  func testNestedPropertyWrappersCanMergeDefaultCodableWithDateStrategy() throws {
+  @Test func testNestedPropertyWrappersCanMergeDefaultCodableWithDateStrategy() throws {
     let _1970 = Date(timeIntervalSince1970: 0)
     let _1971 = Date(timeIntervalSince1970: 31536000)
 
@@ -86,15 +87,15 @@ final class DefaultCodableTest_NestedPropertyWrapper: XCTestCase {
     let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
     let fixture3 = try JSONDecoder().decode(Fixture.self, from: jsonData3)
 
-    XCTAssertEqual(fixture1.returnDate, _1970)
-    XCTAssertEqual(fixture2.returnDate, _1970)
-    XCTAssertEqual(fixture3.returnDate, _1971)
+    #expect(fixture1.returnDate == _1970)
+    #expect(fixture2.returnDate == _1970)
+    #expect(fixture3.returnDate == _1971)
   }
 }
 
 // MARK: - Types with Containers
 
-final class DefaultCodableTests_TypesWithContainers: XCTestCase {
+struct DefaultCodableTests_TypesWithContainers {
   struct ArrayContainer: Codable {
     var value: [Int]
   }
@@ -121,30 +122,30 @@ final class DefaultCodableTests_TypesWithContainers: XCTestCase {
     public var type: DictionaryContainer
   }
 
-  func testDecodingAndEncodingWithArrayContainer() throws {
+  @Test func testDecodingAndEncodingWithArrayContainer() throws {
     let jsonData = #"{ "type": { "value": [2, 4, 6] } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
-    XCTAssertEqual(fixture.type.value, [2, 4, 6])
+    #expect(fixture.type.value == [2, 4, 6])
 
     let data = try JSONEncoder().encode(fixture)
     let str = String(data: data, encoding: .utf8)
-    XCTAssertEqual(str, #"{"type":{"value":[2,4,6]}}"#)
+    #expect(str == #"{"type":{"value":[2,4,6]}}"#)
   }
 
-  func testDecodingAndEncodingWithDictionaryContainer() throws {
+  @Test func testDecodingAndEncodingWithDictionaryContainer() throws {
     let jsonData = #"{ "type": { "value": {"b": 17 } } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture2.self, from: jsonData)
-    XCTAssertEqual(fixture.type.value, ["b": 17])
+    #expect(fixture.type.value == ["b": 17])
 
     let data = try JSONEncoder().encode(fixture)
     let str = String(data: data, encoding: .utf8)
-    XCTAssertEqual(str, #"{"type":{"value":{"b":17}}}"#)
+    #expect(str == #"{"type":{"value":{"b":17}}}"#)
   }
 }
 
 // MARK: - Enums with Associated Values
 
-final class DefaultCodableTests_EnumWithAssociatedValue: XCTestCase {
+struct DefaultCodableTests_EnumWithAssociatedValue {
   enum Zar: Equatable {
     case ziz(Int)
     case zaz(Int)
@@ -194,16 +195,16 @@ final class DefaultCodableTests_EnumWithAssociatedValue: XCTestCase {
     public var value: CustomType
   }
 
-  func testDecodingAndEncodingCustomEnumWithAssociatedValue() throws {
+  @Test func testDecodingAndEncodingCustomEnumWithAssociatedValue() throws {
     let jsonData = #"{ "value": { "fish": "ziz", "int": 4 } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
-    XCTAssertEqual(fixture.value.z, .ziz(4))
+    #expect(fixture.value.z == .ziz(4))
 
     let encoder = JSONEncoder()
     encoder.outputFormatting = .sortedKeys
 
     let data = try encoder.encode(fixture)
     let str = String(data: data, encoding: .utf8)
-    XCTAssertEqual(str, #"{"value":{"fish":"ziz","int":4}}"#)
+    #expect(str == #"{"value":{"fish":"ziz","int":4}}"#)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyArrayTests.swift
@@ -5,11 +5,12 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultEmptyArrayTests: XCTestCase {
+struct DefaultEmptyArrayTests {
   struct Fixture: Equatable, Codable {
     struct NestedFixture: Equatable, Codable {
       var one: String
@@ -20,7 +21,7 @@ final class DefaultEmptyArrayTests: XCTestCase {
     @DefaultEmptyArray var nonPrimitiveValues: [NestedFixture]
   }
 
-  func testDecodingFailableArrayDefaultsToEmptyArray() throws {
+  @Test func testDecodingFailableArrayDefaultsToEmptyArray() throws {
     // given
     let jsonData = #"{ "values": null, "nonPrimitiveValues": null }"#.data(using: .utf8)!
 
@@ -28,11 +29,11 @@ final class DefaultEmptyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [])
+    #expect(fixture.values == [])
+    #expect(fixture.nonPrimitiveValues == [])
   }
 
-  func testDecodingKeyNotPresentDefaultsToEmptyArray() throws {
+  @Test func testDecodingKeyNotPresentDefaultsToEmptyArray() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -40,11 +41,11 @@ final class DefaultEmptyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [])
+    #expect(fixture.values == [])
+    #expect(fixture.nonPrimitiveValues == [])
   }
 
-  func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
+  @Test func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
     // given
     let jsonData = #"{ "values": null, "nonPrimitiveValues": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -56,11 +57,11 @@ final class DefaultEmptyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 2, 3])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [Fixture.NestedFixture(one: "a", two: ["b": ["c"]])])
+    #expect(fixture.values == [1, 2, 3])
+    #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "a", two: ["b": ["c"]])])
   }
 
-  func testEncodingDecodedFulfillableArrayRetainsContents() throws {
+  @Test func testEncodingDecodedFulfillableArrayRetainsContents() throws {
     // given
     let jsonData = #"{ "values": [1, 2], "nonPrimitiveValues": [{ "one": "one", "two": {"key": ["value"]}}] }"#
       .data(using: .utf8)!
@@ -71,7 +72,7 @@ final class DefaultEmptyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 2])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [Fixture.NestedFixture(one: "one", two: ["key": ["value"]])])
+    #expect(fixture.values == [1, 2])
+    #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "one", two: ["key": ["value"]])])
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyStringTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyStringTests.swift
@@ -6,16 +6,17 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultEmptyStringTests: XCTestCase {
+struct DefaultEmptyStringTests {
   struct Fixture: Equatable, Codable {
     @DefaultEmptyString var string: String
   }
 
-  func testDecodingFailableStringDefaultEmptyString() throws {
+  @Test func testDecodingFailableStringDefaultEmptyString() throws {
     // given
     let jsonData = #"{ "string": null }"#.data(using: .utf8)!
 
@@ -23,10 +24,10 @@ final class DefaultEmptyStringTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.string, "")
+    #expect(fixture.string == "")
   }
 
-  func testDecodingKeyNotPresentDefaultEmptyString() throws {
+  @Test func testDecodingKeyNotPresentDefaultEmptyString() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -34,10 +35,10 @@ final class DefaultEmptyStringTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.string, "")
+    #expect(fixture.string == "")
   }
 
-  func testDecodinSuccessDefaultEmptyString() throws {
+  @Test func testDecodinSuccessDefaultEmptyString() throws {
     // given
     let jsonData = #"{ "string": "hi" }"#.data(using: .utf8)!
 
@@ -45,6 +46,6 @@ final class DefaultEmptyStringTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.string, "hi")
+    #expect(fixture.string == "hi")
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultFalseTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultFalseTests.swift
@@ -6,16 +6,17 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultFalseTests: XCTestCase {
+struct DefaultFalseTests {
   struct Fixture: Equatable, Codable {
     @DefaultFalse var truthy: Bool
   }
 
-  func testDecodingFailableArrayDefaultsToFalse() throws {
+  @Test func testDecodingFailableArrayDefaultsToFalse() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
 
@@ -23,10 +24,10 @@ final class DefaultFalseTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.truthy, false)
+    #expect(fixture.truthy == false)
   }
 
-  func testDecodingKeyNotPresentDefaultsToFalse() throws {
+  @Test func testDecodingKeyNotPresentDefaultsToFalse() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -34,10 +35,10 @@ final class DefaultFalseTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.truthy, false)
+    #expect(fixture.truthy == false)
   }
 
-  func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
+  @Test func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -48,10 +49,10 @@ final class DefaultFalseTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
+    #expect(fixture.truthy == true)
   }
 
-  func testEncodingDecodedFulfillableBoolRetainsValue() throws {
+  @Test func testEncodingDecodedFulfillableBoolRetainsValue() throws {
     // given
     let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -61,10 +62,10 @@ final class DefaultFalseTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
+    #expect(fixture.truthy == true)
   }
 
-  func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
+  @Test func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
     // given
     let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
@@ -74,11 +75,11 @@ final class DefaultFalseTests: XCTestCase {
     let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
-    XCTAssertEqual(fixture2.truthy, false)
+    #expect(fixture.truthy == true)
+    #expect(fixture2.truthy == false)
   }
 
-  func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
+  @Test func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
     // given
     let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!
@@ -88,11 +89,11 @@ final class DefaultFalseTests: XCTestCase {
     let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
-    XCTAssertEqual(fixture2.truthy, false)
+    #expect(fixture.truthy == true)
+    #expect(fixture2.truthy == false)
   }
 
-  func testDecodingInvalidValueDecodesToDefaultValue() throws {
+  @Test func testDecodingInvalidValueDecodesToDefaultValue() throws {
     // given
     let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
 
@@ -100,10 +101,6 @@ final class DefaultFalseTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(
-      fixture.truthy,
-      false,
-      "Should fall in to the else block and return default value"
-    )
+    #expect(fixture.truthy == false, "Should fall in to the else block and return default value")
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultTrueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultTrueTests.swift
@@ -5,16 +5,17 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultTrueTests: XCTestCase {
+struct DefaultTrueTests {
   struct Fixture: Equatable, Codable {
     @DefaultTrue var truthy: Bool
   }
 
-  func testDecodingFailableArrayDefaultsToFalse() throws {
+  @Test func testDecodingFailableArrayDefaultsToFalse() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
 
@@ -22,10 +23,10 @@ final class DefaultTrueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
+    #expect(fixture.truthy == true)
   }
 
-  func testDecodingKeyNotPresentDefaultsToFalse() throws {
+  @Test func testDecodingKeyNotPresentDefaultsToFalse() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -33,10 +34,10 @@ final class DefaultTrueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
+    #expect(fixture.truthy == true)
   }
 
-  func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
+  @Test func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -47,10 +48,10 @@ final class DefaultTrueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.truthy, false)
+    #expect(fixture.truthy == false)
   }
 
-  func testEncodingDecodedFulfillableBoolRetainsValue() throws {
+  @Test func testEncodingDecodedFulfillableBoolRetainsValue() throws {
     // given
     let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -60,10 +61,10 @@ final class DefaultTrueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
+    #expect(fixture.truthy == true)
   }
 
-  func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
+  @Test func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
     // given
     let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
@@ -73,11 +74,11 @@ final class DefaultTrueTests: XCTestCase {
     let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
-    XCTAssertEqual(fixture2.truthy, false)
+    #expect(fixture.truthy == true)
+    #expect(fixture2.truthy == false)
   }
 
-  func testDecodingInvalidValueDecodesToDefaultValue() throws {
+  @Test func testDecodingInvalidValueDecodesToDefaultValue() throws {
     // given
     let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
 
@@ -85,14 +86,10 @@ final class DefaultTrueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(
-      fixture.truthy,
-      true,
-      "Should fall in to the else block and return default value"
-    )
+    #expect(fixture.truthy == true, "Should fall in to the else block and return default value")
   }
 
-  func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
+  @Test func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
     // given
     let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!
@@ -102,7 +99,7 @@ final class DefaultTrueTests: XCTestCase {
     let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
 
     // then
-    XCTAssertEqual(fixture.truthy, true)
-    XCTAssertEqual(fixture2.truthy, false)
+    #expect(fixture.truthy == true)
+    #expect(fixture2.truthy == false)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroDoubleTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroDoubleTests.swift
@@ -6,16 +6,17 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultZeroDoubleTests: XCTestCase {
+struct DefaultZeroDoubleTests {
   struct Fixture: Equatable, Codable {
     @DefaultZeroDouble var doubleValue: Double
   }
 
-  func testDecodingFailableDoubleDefaultZeroDouble() throws {
+  @Test func testDecodingFailableDoubleDefaultZeroDouble() throws {
     // given
     let jsonData = #"{ "doubleValue": null }"#.data(using: .utf8)!
 
@@ -23,10 +24,10 @@ final class DefaultZeroDoubleTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.doubleValue, 0.0)
+    #expect(fixture.doubleValue == 0.0)
   }
 
-  func testDecodingKeyNotPresentDefaultZeroDouble() throws {
+  @Test func testDecodingKeyNotPresentDefaultZeroDouble() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -34,10 +35,10 @@ final class DefaultZeroDoubleTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.doubleValue, 0.0)
+    #expect(fixture.doubleValue == 0.0)
   }
 
-  func testDecodinSuccessDefaultZeroDouble() throws {
+  @Test func testDecodinSuccessDefaultZeroDouble() throws {
     // given
     let jsonData = #"{ "doubleValue": 0.001 }"#.data(using: .utf8)!
 
@@ -45,6 +46,6 @@ final class DefaultZeroDoubleTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.doubleValue, 0.001)
+    #expect(fixture.doubleValue == 0.001)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroFloatTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroFloatTests.swift
@@ -6,16 +6,17 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultZeroFloatTests: XCTestCase {
+struct DefaultZeroFloatTests {
   struct Fixture: Equatable, Codable {
     @DefaultZeroFloat var floatValue: Float
   }
 
-  func testDecodingFailableFloatDefaultZeroFloat() throws {
+  @Test func testDecodingFailableFloatDefaultZeroFloat() throws {
     // given
     let jsonData = #"{ "floatValue": null }"#.data(using: .utf8)!
 
@@ -23,10 +24,10 @@ final class DefaultZeroFloatTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.floatValue, 0.0)
+    #expect(fixture.floatValue == 0.0)
   }
 
-  func testDecodingKeyNotPresentDefaultZeroFloat() throws {
+  @Test func testDecodingKeyNotPresentDefaultZeroFloat() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -34,10 +35,10 @@ final class DefaultZeroFloatTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.floatValue, 0.0)
+    #expect(fixture.floatValue == 0.0)
   }
 
-  func testDecodinSuccessDefaultZeroFloat() throws {
+  @Test func testDecodinSuccessDefaultZeroFloat() throws {
     // given
     let jsonData = #"{ "floatValue": 0.001 }"#.data(using: .utf8)!
 
@@ -45,6 +46,6 @@ final class DefaultZeroFloatTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.floatValue, 0.001)
+    #expect(fixture.floatValue == 0.001)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroIntTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroIntTests.swift
@@ -5,16 +5,17 @@
 //  Created by Elon on 2023/04/27.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultZeroIntTests: XCTestCase {
+struct DefaultZeroIntTests {
   struct Fixture: Equatable, Codable {
     @DefaultZeroInt var intValue: Int
   }
 
-  func testDecodingFailableIntDefaultZeroInt() throws {
+  @Test func testDecodingFailableIntDefaultZeroInt() throws {
     // given
     let jsonData = #"{ "intValue": null }"#.data(using: .utf8)!
 
@@ -22,10 +23,10 @@ final class DefaultZeroIntTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.intValue, 0)
+    #expect(fixture.intValue == 0)
   }
 
-  func testDecodingKeyNotPresentDefaultZeroInt() throws {
+  @Test func testDecodingKeyNotPresentDefaultZeroInt() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -33,10 +34,10 @@ final class DefaultZeroIntTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.intValue, 0)
+    #expect(fixture.intValue == 0)
   }
 
-  func testDecodinSuccessDefaultZeroInt() throws {
+  @Test func testDecodinSuccessDefaultZeroInt() throws {
     // given
     let jsonData = #"{ "intValue": 999 }"#.data(using: .utf8)!
 
@@ -44,6 +45,6 @@ final class DefaultZeroIntTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.intValue, 999)
+    #expect(fixture.intValue == 999)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayTests.swift
@@ -5,11 +5,12 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class LosslessArrayTests: XCTestCase {
+struct LosslessArrayTests {
   struct Fixture: Equatable, Codable {
     @LosslessArray var values: [Int]
   }
@@ -18,7 +19,7 @@ final class LosslessArrayTests: XCTestCase {
     @LosslessArray var values: [String]
   }
 
-  func testDecodingLosslessArrayActsLikeLossyArray() throws {
+  @Test func testDecodingLosslessArrayActsLikeLossyArray() throws {
     // given
     let jsonData = #"{ "values": [1, null, 3, 4] }"#.data(using: .utf8)!
 
@@ -26,10 +27,10 @@ final class LosslessArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 3, 4])
+    #expect(fixture.values == [1, 3, 4])
   }
 
-  func testDecodingIntsConvertsStringsIntoLosslessElements() throws {
+  @Test func testDecodingIntsConvertsStringsIntoLosslessElements() throws {
     // given
     let jsonData = #"{ "values": ["1", 2, null, "4"] }"#.data(using: .utf8)!
 
@@ -37,10 +38,10 @@ final class LosslessArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 2, 4])
+    #expect(fixture.values == [1, 2, 4])
   }
 
-  func testDecodingStringsPreservesLosslessElements() throws {
+  @Test func testDecodingStringsPreservesLosslessElements() throws {
     // given
     let jsonData = #"{ "values": ["1", 2, 3.14, null, false, "4"] }"#.data(using: .utf8)!
 
@@ -48,10 +49,10 @@ final class LosslessArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture2.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, ["1", "2", "3.14", "false", "4"])
+    #expect(fixture.values == ["1", "2", "3.14", "false", "4"])
   }
 
-  func testEncodingDecodedLosslessArrayIgnoresFailableElements() throws {
+  @Test func testEncodingDecodedLosslessArrayIgnoresFailableElements() throws {
     // given
     let jsonData = #"{ "values": [null, "2", null, 4] }"#.data(using: .utf8)!
 
@@ -66,10 +67,10 @@ final class LosslessArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [2, 4, 5])
+    #expect(fixture.values == [2, 4, 5])
   }
 
-  func testEncodingDecodedLosslessArrayRetainsContents() throws {
+  @Test func testEncodingDecodedLosslessArrayRetainsContents() throws {
     // given
     let jsonData = #"{ "values": [1, 2, "3"] }"#.data(using: .utf8)!
 
@@ -81,6 +82,6 @@ final class LosslessArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 2, 3])
+    #expect(fixture.values == [1, 2, 3])
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessCustomValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessCustomValueTests.swift
@@ -5,7 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
@@ -22,7 +23,7 @@ struct MyLosslessStrategy<Value: LosslessStringCodable>: LosslessDecodingStrateg
 
 typealias MyLosslessType<T> = LosslessValueCodable<MyLosslessStrategy<T>> where T: LosslessStringCodable
 
-final class LosslessCustomValueTests: XCTestCase {
+struct LosslessCustomValueTests {
   struct Fixture: Equatable, Codable {
     @MyLosslessType var int: Int
     @MyLosslessType var string: String
@@ -30,7 +31,7 @@ final class LosslessCustomValueTests: XCTestCase {
     @MyLosslessType var bool: Bool
   }
 
-  func testDecodingCustomLosslessStrategyDecodesCorrectly() throws {
+  @Test func testDecodingCustomLosslessStrategyDecodesCorrectly() throws {
     // given
     let jsonData = #"{ "string": 7, "int": "1", "fortytwo": null, "bool": true }"#.data(using: .utf8)!
 
@@ -38,17 +39,17 @@ final class LosslessCustomValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.string, "7")
-    XCTAssertEqual(fixture.int, 1)
-    XCTAssertEqual(fixture.fortytwo, 42)
-    XCTAssertEqual(fixture.bool, true)
+    #expect(fixture.string == "7")
+    #expect(fixture.int == 1)
+    #expect(fixture.fortytwo == 42)
+    #expect(fixture.bool == true)
   }
 
-  func testDecodingCustomLosslessStrategyWithBrokenFieldsThrowsError() throws {
+  @Test func testDecodingCustomLosslessStrategyWithBrokenFieldsThrowsError() throws {
     // given
     let jsonData = #"{ "string": 7, "int": "1", "fortytwo": null, "bool": 9 }"#.data(using: .utf8)!
 
     // when/then
-    XCTAssertThrowsError(try JSONDecoder().decode(Fixture.self, from: jsonData))
+    #expect(throws: (any Error).self) { try JSONDecoder().decode(Fixture.self, from: jsonData) }
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueTests.swift
@@ -5,11 +5,12 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class LosslessValueTests: XCTestCase {
+struct LosslessValueTests {
   struct Fixture: Equatable, Codable {
     @LosslessValue var bool: Bool
     @LosslessValue var string: String
@@ -17,7 +18,7 @@ final class LosslessValueTests: XCTestCase {
     @LosslessValue var double: Double
   }
 
-  func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
+  @Test func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
     // given
     let jsonData = #"{ "bool": "true", "string": 42, "int": "1", "double": "7.1" }"#.data(using: .utf8)!
 
@@ -25,13 +26,13 @@ final class LosslessValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.bool, true)
-    XCTAssertEqual(fixture.string, "42")
-    XCTAssertEqual(fixture.int, 1)
-    XCTAssertEqual(fixture.double, 7.1)
+    #expect(fixture.bool == true)
+    #expect(fixture.string == "42")
+    #expect(fixture.int == 1)
+    #expect(fixture.double == 7.1)
   }
 
-  func testDecodingEncodedMisalignedTypesFromJSONDecodesCorrectTypes() throws {
+  @Test func testDecodingEncodedMisalignedTypesFromJSONDecodesCorrectTypes() throws {
     // given
     let jsonData = #"{ "bool": "true", "string": 42, "int": "7", "double": "7.1" }"#.data(using: .utf8)!
 
@@ -47,13 +48,13 @@ final class LosslessValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.bool, false)
-    XCTAssertEqual(fixture.string, "42")
-    XCTAssertEqual(fixture.int, 7)
-    XCTAssertEqual(fixture.double, 3.14)
+    #expect(fixture.bool == false)
+    #expect(fixture.string == "42")
+    #expect(fixture.int == 7)
+    #expect(fixture.double == 3.14)
   }
 
-  func testEncodingAndDecodedExpectedTypes() throws {
+  @Test func testEncodingAndDecodedExpectedTypes() throws {
     // given
     let jsonData = #"{ "bool": true, "string": "42", "int": 7, "double": 7.1 }"#.data(using: .utf8)!
 
@@ -65,13 +66,13 @@ final class LosslessValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.bool, true)
-    XCTAssertEqual(fixture.string, "42")
-    XCTAssertEqual(fixture.int, 7)
-    XCTAssertEqual(fixture.double, 7.1)
+    #expect(fixture.bool == true)
+    #expect(fixture.string == "42")
+    #expect(fixture.int == 7)
+    #expect(fixture.double == 7.1)
   }
 
-  func testDecodingBoolIntValueFromJSONDecodesCorrectly() throws {
+  @Test func testDecodingBoolIntValueFromJSONDecodesCorrectly() throws {
     struct FixtureWithBooleanAsInteger: Equatable, Codable {
       @LosslessBoolValue var bool: Bool
       @LosslessValue var string: String
@@ -90,13 +91,13 @@ final class LosslessValueTests: XCTestCase {
     let fixture = try JSONDecoder().decode(FixtureWithBooleanAsInteger.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.bool, true)
-    XCTAssertEqual(fixture.string, "42")
-    XCTAssertEqual(fixture.int, 7)
-    XCTAssertEqual(fixture.double, 7.1)
+    #expect(fixture.bool == true)
+    #expect(fixture.string == "42")
+    #expect(fixture.int == 7)
+    #expect(fixture.double == 7.1)
   }
 
-  func testBoolAsIntegerShouldNotConflictWithDefaultStrategy() throws {
+  @Test func testBoolAsIntegerShouldNotConflictWithDefaultStrategy() throws {
     struct Response: Codable {
       @LosslessValue var id: String
       @LosslessBoolValue var bool: Bool
@@ -109,11 +110,11 @@ final class LosslessValueTests: XCTestCase {
     let result = try JSONDecoder().decode(Response.self, from: json)
 
     // then
-    XCTAssertEqual(result.id, "1")
-    XCTAssertEqual(result.bool, true)
+    #expect(result.id == "1")
+    #expect(result.bool == true)
   }
 
-  func testDecodingBoolAsLogicalString() throws {
+  @Test func testDecodingBoolAsLogicalString() throws {
     struct Response: Codable {
       @LosslessBoolValue var a: Bool
       @LosslessBoolValue var b: Bool
@@ -132,13 +133,13 @@ final class LosslessValueTests: XCTestCase {
     let result = try JSONDecoder().decode(Response.self, from: json)
 
     // then
-    XCTAssertEqual(result.a, true)
-    XCTAssertEqual(result.b, true)
-    XCTAssertEqual(result.c, true)
-    XCTAssertEqual(result.d, true)
-    XCTAssertEqual(result.e, true)
-    XCTAssertEqual(result.f, true)
-    XCTAssertEqual(result.g, true)
+    #expect(result.a == true)
+    #expect(result.b == true)
+    #expect(result.c == true)
+    #expect(result.d == true)
+    #expect(result.e == true)
+    #expect(result.f == true)
+    #expect(result.g == true)
 
     // given
     let json2 = #"{ "a": "FALSE", "b": "no", "c": "0", "d": "n", "e": "f","f":"-11", "g":-11  }"#
@@ -148,12 +149,12 @@ final class LosslessValueTests: XCTestCase {
     let result2 = try JSONDecoder().decode(Response.self, from: json2)
 
     // then
-    XCTAssertEqual(result2.a, false)
-    XCTAssertEqual(result2.b, false)
-    XCTAssertEqual(result2.c, false)
-    XCTAssertEqual(result2.d, false)
-    XCTAssertEqual(result2.e, false)
-    XCTAssertEqual(result2.f, false)
-    XCTAssertEqual(result2.g, false)
+    #expect(result2.a == false)
+    #expect(result2.b == false)
+    #expect(result2.c == false)
+    #expect(result2.d == false)
+    #expect(result2.e == false)
+    #expect(result2.f == false)
+    #expect(result2.g == false)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayTests.swift
@@ -5,11 +5,12 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class LossyArrayTests: XCTestCase {
+struct LossyArrayTests {
   struct Fixture: Equatable, Codable {
     struct NestedFixture: Equatable, Codable {
       var one: String
@@ -20,7 +21,7 @@ final class LossyArrayTests: XCTestCase {
     @LossyArray var nonPrimitiveValues: [NestedFixture]
   }
 
-  func testDecodingLossyArrayIgnoresFailableElements() throws {
+  @Test func testDecodingLossyArrayIgnoresFailableElements() throws {
     // given
     let jsonData = #"{ "values": [1, null, 3, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
 
@@ -28,11 +29,11 @@ final class LossyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 3, 4])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [])
+    #expect(fixture.values == [1, 3, 4])
+    #expect(fixture.nonPrimitiveValues == [])
   }
 
-  func testDecodingLossyArrayIgnoresLossyElements() throws {
+  @Test func testDecodingLossyArrayIgnoresLossyElements() throws {
     // given
     let jsonData = #"{ "values": [1, null, "3", false, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
 
@@ -40,11 +41,11 @@ final class LossyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 4])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [])
+    #expect(fixture.values == [1, 4])
+    #expect(fixture.nonPrimitiveValues == [])
   }
 
-  func testEncodingDecodedLossyArrayIgnoresFailableElements() throws {
+  @Test func testEncodingDecodedLossyArrayIgnoresFailableElements() throws {
     // given
     let jsonData = #"{ "values": [null, 2, null, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -56,11 +57,11 @@ final class LossyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [2, 4, 5])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [Fixture.NestedFixture(one: "1", two: ["x": ["y"]])])
+    #expect(fixture.values == [2, 4, 5])
+    #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "1", two: ["x": ["y"]])])
   }
 
-  func testEncodingDecodedLossyArrayRetainsContents() throws {
+  @Test func testEncodingDecodedLossyArrayRetainsContents() throws {
     // given
     let jsonData = #"{ "values": [1, 2], "nonPrimitiveValues": [{ "one": "one", "two": {"key": ["value"]}}] }"#
       .data(using: .utf8)!
@@ -71,11 +72,11 @@ final class LossyArrayTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.values, [1, 2])
-    XCTAssertEqual(fixture.nonPrimitiveValues, [Fixture.NestedFixture(one: "one", two: ["key": ["value"]])])
+    #expect(fixture.values == [1, 2])
+    #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "one", two: ["key": ["value"]])])
   }
 
-  func testEncodingDecodingLossyArrayWorksWithCustomStrategies() throws {
+  @Test func testEncodingDecodingLossyArrayWorksWithCustomStrategies() throws {
     // given
     struct Fixture: Equatable, Codable {
       @LossyArray var theValues: [Date]
@@ -89,7 +90,7 @@ final class LossyArrayTests: XCTestCase {
     let fixture = try decoder.decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.theValues, [Date(timeIntervalSince1970: 123)])
+    #expect(fixture.theValues == [Date(timeIntervalSince1970: 123)])
 
     // given
     let encoder = JSONEncoder()
@@ -101,6 +102,6 @@ final class LossyArrayTests: XCTestCase {
     let fixture2 = try decoder.decode(Fixture.self, from: data)
 
     // then
-    XCTAssertEqual(fixture2.theValues, [Date(timeIntervalSince1970: 123)])
+    #expect(fixture2.theValues == [Date(timeIntervalSince1970: 123)])
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryTests.swift
@@ -5,17 +5,18 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class LossyDictionaryTests: XCTestCase {
+struct LossyDictionaryTests {
   struct Fixture: Equatable, Codable {
     @LossyDictionary var stringToInt: [String: Int]
     @LossyDictionary var intToString: [Int: String]
   }
 
-  func testDecodingLossyDictionaryIgnoresFailableElements() throws {
+  @Test func testDecodingLossyDictionaryIgnoresFailableElements() throws {
     // given
     let jsonData = """
       {
@@ -36,11 +37,11 @@ final class LossyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, ["one": 1, "two": 2])
-    XCTAssertEqual(fixture.intToString, [1: "one", 2: "two"])
+    #expect(fixture.stringToInt == ["one": 1, "two": 2])
+    #expect(fixture.intToString == [1: "one", 2: "two"])
   }
 
-  func testEncodingDecodedLossyDictionaryIgnoresFailableElements() throws {
+  @Test func testEncodingDecodedLossyDictionaryIgnoresFailableElements() throws {
     // given
     let jsonData = """
       {
@@ -65,11 +66,11 @@ final class LossyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, ["one": 1, "two": 2, "three": 3])
-    XCTAssertEqual(fixture.intToString, [1: "one", 2: "two", 3: "three"])
+    #expect(fixture.stringToInt == ["one": 1, "two": 2, "three": 3])
+    #expect(fixture.intToString == [1: "one", 2: "two", 3: "three"])
   }
 
-  func testEncodingDecodedLosslessArrayRetainsContents() throws {
+  @Test func testEncodingDecodedLosslessArrayRetainsContents() throws {
     // given
     let jsonData = """
       {
@@ -90,11 +91,11 @@ final class LossyDictionaryTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertEqual(fixture.stringToInt, ["one": 1, "two": 2, "three": 3])
-    XCTAssertEqual(fixture.intToString, [1: "one", 2: "two", 3: "three"])
+    #expect(fixture.stringToInt == ["one": 1, "two": 2, "three": 3])
+    #expect(fixture.intToString == [1: "one", 2: "two", 3: "three"])
   }
 
-  func testEncodingLosslessDictionaryRetainsKeys() throws {
+  @Test func testEncodingLosslessDictionaryRetainsKeys() throws {
     // given
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -115,6 +116,6 @@ final class LossyDictionaryTests: XCTestCase {
     let reencodedFixture = try decoder.decode(Fixture.self, from: encoder.encode(fixture))
 
     // then
-    XCTAssertEqual(reencodedFixture, fixture)
+    #expect(reencodedFixture == fixture)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalTests.swift
@@ -5,15 +5,16 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class DefaultNilTests: XCTestCase {
+struct DefaultNilTests {
   /// This test demonstrates the problem that `@LossyOptional` solves. When decoding
   /// optional types, it often the case that we end up with an error instead of
   /// defaulting back to `nil`.
-  func testDecodingBadUrlAsOptionalWithoutDefaultNil() {
+  @Test func testDecodingBadUrlAsOptionalWithoutDefaultNil() {
     // given
     struct Fixture: Codable {
       var a: URL?
@@ -21,10 +22,10 @@ final class DefaultNilTests: XCTestCase {
     let jsonData = #"{"a":"https://example .com"}"#.data(using: .utf8)!
 
     // when/then
-    XCTAssertThrowsError(try JSONDecoder().decode(Fixture.self, from: jsonData))
+    #expect(throws: (any Error).self) { try JSONDecoder().decode(Fixture.self, from: jsonData) }
   }
 
-  func testDecodingWithUrlConversions() throws {
+  @Test func testDecodingWithUrlConversions() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: URL?
@@ -38,11 +39,11 @@ final class DefaultNilTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.a)
-    XCTAssertEqual(fixture.b, URL(string: goodUrlString))
+    #expect(fixture.a == nil)
+    #expect(fixture.b == URL(string: goodUrlString))
   }
 
-  func testDecodingWithIntegerConversions() throws {
+  @Test func testDecodingWithIntegerConversions() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: Int?
@@ -56,11 +57,11 @@ final class DefaultNilTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertNil(fixture.a)
-    XCTAssertEqual(fixture.b, 3)
+    #expect(fixture.a == nil)
+    #expect(fixture.b == 3)
   }
 
-  func testDecodingWithNullValue() throws {
+  @Test func testDecodingWithNullValue() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: String?
@@ -71,10 +72,10 @@ final class DefaultNilTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
 
     // then
-    XCTAssertNil(fixture.a)
+    #expect(fixture.a == nil)
   }
 
-  func testDecodingWithMissingKey() throws {
+  @Test func testDecodingWithMissingKey() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: String?
@@ -87,6 +88,6 @@ final class DefaultNilTests: XCTestCase {
     let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
 
     // then
-    XCTAssertNil(fixture.a)
+    #expect(fixture.a == nil)
   }
 }

--- a/Tests/KarrotCodableKitTests/BetterCodable/RawRepresentableTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/RawRepresentableTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 @testable import KarrotCodableKit
 
-class RawRepresentableTests: XCTestCase {
+struct RawRepresentableTests {
 
-  func testEnumDecodingWithDefaultValue() throws {
+  @Test func testEnumDecodingWithDefaultValue() throws {
     // given
     enum VehicleType: String, Codable, DefaultCodableStrategy {
       case car
@@ -36,6 +37,6 @@ class RawRepresentableTests: XCTestCase {
     let car = try JSONDecoder().decode(Vehicle.self, from: json)
 
     // then
-    XCTAssertEqual(car.vehicleType, .unknown)
+    #expect(car.vehicleType == .unknown)
   }
 }

--- a/Tests/KarrotCodableKitTests/Encodable+ToDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/Encodable+ToDictionaryTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class Encodable_ToDictionaryTests: XCTestCase {
+struct Encodable_ToDictionaryTests {
 
-  func test_toDictionary() throws {
+  @Test func test_toDictionary() throws {
     // given
     let dummy = ObjectDummy(
       id: 1,
@@ -24,14 +25,14 @@ final class Encodable_ToDictionaryTests: XCTestCase {
     let dict = try dummy.toDictionary()
 
     // then
-    XCTAssertEqual(dict["id"] as? Int, 1)
-    XCTAssertEqual(dict["name"] as? String, "ray")
+    #expect(dict["id"] as? Int == 1)
+    #expect(dict["name"] as? String == "ray")
 
     let wallet = dict["wallet"] as? [String: Any]
-    XCTAssertEqual(wallet?["money"] as? Int, 1000)
+    #expect(wallet?["money"] as? Int == 1000)
   }
 
-  func test_asDictionary_optional() throws {
+  @Test func test_asDictionary_optional() throws {
     // given
     let dummy = OptionalDummy(value: nil)
 
@@ -39,7 +40,7 @@ final class Encodable_ToDictionaryTests: XCTestCase {
     let dict = try dummy.toDictionary()
 
     // then
-    XCTAssertEqual(dict.count, 0)
+    #expect(dict.count == 0)
   }
 }
 

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-class DefaultEmptyPolymorphicArrayValueTests: XCTestCase {
+struct DefaultEmptyPolymorphicArrayValueTests {
 
-  func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let response = OptionalArrayDummyResponse(
       notices1: [
@@ -48,10 +49,10 @@ class DefaultEmptyPolymorphicArrayValueTests: XCTestCase {
 
     // then
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 
-  func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let jsonData = #"""
     {
@@ -69,12 +70,12 @@ class DefaultEmptyPolymorphicArrayValueTests: XCTestCase {
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertEqual(result.notices1.count, 1)
-    XCTAssertEqual(result.notices1.first?.type, .callout)
-    XCTAssertTrue(result.notices2.isEmpty)
+    #expect(result.notices1.count == 1)
+    #expect(result.notices1.first?.type == .callout)
+    #expect(result.notices2.isEmpty)
   }
 
-  func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let json = #"""
     {
@@ -87,8 +88,8 @@ class DefaultEmptyPolymorphicArrayValueTests: XCTestCase {
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(json.utf8))
 
     // then
-    XCTAssertTrue(result.notices1.isEmpty)
-    XCTAssertTrue(result.notices2.isEmpty)
+    #expect(result.notices1.isEmpty)
+    #expect(result.notices2.isEmpty)
 
     // when
     let encoder = JSONEncoder()
@@ -107,12 +108,12 @@ class DefaultEmptyPolymorphicArrayValueTests: XCTestCase {
     }
     """#
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 }
 
 extension DefaultEmptyPolymorphicArrayValueTests {
-  func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let jsonData = #"""
     {
@@ -134,12 +135,12 @@ extension DefaultEmptyPolymorphicArrayValueTests {
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertTrue(result.notices1.isEmpty)
+    #expect(result.notices1.isEmpty)
   }
 }
 
 extension DefaultEmptyPolymorphicArrayValueTests {
-  func testDecodingOnlyValue() throws {
+  @Test func testDecodingOnlyValue() throws {
     // given
     let jsonData = #"""
     {
@@ -161,8 +162,8 @@ extension DefaultEmptyPolymorphicArrayValueTests {
     )
 
     // then
-    XCTAssertTrue(result.notices1.isEmpty)
-    XCTAssertEqual(result.notices2.first?.type, .callout)
-    XCTAssertTrue(result.notices3.isEmpty)
+    #expect(result.notices1.isEmpty)
+    #expect(result.notices2.first?.type == .callout)
+    #expect(result.notices3.isEmpty)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-class PolymorphicLossyArrayValueTests: XCTestCase {
+struct PolymorphicLossyArrayValueTests {
 
-  func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let response = OptionalLossyArrayDummyResponse(
       notices1: [
@@ -48,10 +49,10 @@ class PolymorphicLossyArrayValueTests: XCTestCase {
 
     // then
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 
-  func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let jsonData = #"""
     {
@@ -69,12 +70,12 @@ class PolymorphicLossyArrayValueTests: XCTestCase {
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertEqual(result.notices1.count, 1)
-    XCTAssertEqual(result.notices1.first?.type, .callout)
-    XCTAssertTrue(result.notices2.isEmpty)
+    #expect(result.notices1.count == 1)
+    #expect(result.notices1.first?.type == .callout)
+    #expect(result.notices2.isEmpty)
   }
 
-  func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
     // given
     let json = #"""
     {
@@ -87,8 +88,8 @@ class PolymorphicLossyArrayValueTests: XCTestCase {
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(json.utf8))
 
     // then
-    XCTAssertTrue(result.notices1.isEmpty)
-    XCTAssertTrue(result.notices2.isEmpty)
+    #expect(result.notices1.isEmpty)
+    #expect(result.notices2.isEmpty)
 
     // when
     let encoder = JSONEncoder()
@@ -107,12 +108,12 @@ class PolymorphicLossyArrayValueTests: XCTestCase {
     }
     """#
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 }
 
 extension PolymorphicLossyArrayValueTests {
-  func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
+  @Test func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
     // given: An array where one element (notice) is missing the required 'description' parameter.
     let jsonData = #"""
     {
@@ -134,13 +135,13 @@ extension PolymorphicLossyArrayValueTests {
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(jsonData.utf8))
 
     // then: Returns an array excluding the element that failed decoding.
-    XCTAssertEqual(result.notices1.count, 1)
-    XCTAssertEqual(result.notices1.first?.description, "test")
+    #expect(result.notices1.count == 1)
+    #expect(result.notices1.first?.description == "test")
   }
 }
 
 extension PolymorphicLossyArrayValueTests {
-  func testDecodingOnlyValue() throws {
+  @Test func testDecodingOnlyValue() throws {
     // given
     let jsonData = #"""
     {
@@ -162,8 +163,8 @@ extension PolymorphicLossyArrayValueTests {
     )
 
     // then
-    XCTAssertTrue(result.notices1.isEmpty)
-    XCTAssertEqual(result.notices2.first?.type, .callout)
-    XCTAssertTrue(result.notices3.isEmpty)
+    #expect(result.notices1.isEmpty)
+    #expect(result.notices2.first?.type == .callout)
+    #expect(result.notices3.isEmpty)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumCodableTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-class PolymorphicEnumCodableTests: XCTestCase {
+struct PolymorphicEnumCodableTests {
 
-  func testPolymorphicEnumValue() throws {
+  @Test func testPolymorphicEnumValue() throws {
     // given
     let json = #"""
     {
@@ -28,9 +29,9 @@ class PolymorphicEnumCodableTests: XCTestCase {
     // then
     switch result {
     case .callout(let value):
-      XCTAssertEqual(value.type, .callout)
+      #expect(value.type == .callout)
     default:
-      XCTFail("Invalid type")
+      Issue.record("Invalid type")
     }
 
     // when
@@ -47,10 +48,10 @@ class PolymorphicEnumCodableTests: XCTestCase {
     }
     """#
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 
-  func testPolymorphicEnumArrayValue() throws {
+  @Test func testPolymorphicEnumArrayValue() throws {
     // given
     let json = #"""
     [
@@ -76,15 +77,15 @@ class PolymorphicEnumCodableTests: XCTestCase {
 
     // then
     if case .callout(let value) = result.first {
-      XCTAssertEqual(value.type, .callout)
+      #expect(value.type == .callout)
     }
     if case .dismissibleCallout(let value) = result.last {
-      XCTAssertEqual(value.type, .dismissibleCallout)
-      XCTAssertEqual(value.key, "hi")
+      #expect(value.type == .dismissibleCallout)
+      #expect(value.key == "hi")
     }
     if case .undefinedCallout(let value) = result.last {
-      XCTAssertEqual(value.type, .undefinedCallout)
-      XCTAssertEqual(value.description, "test")
+      #expect(value.type == .undefinedCallout)
+      #expect(value.description == "test")
     }
 
     // when
@@ -112,6 +113,6 @@ class PolymorphicEnumCodableTests: XCTestCase {
     ]
     """#
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumDecodableTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-class PolymorphicEnumDecodableTests: XCTestCase {
+struct PolymorphicEnumDecodableTests {
 
-  func testPolymorphicEnumValue() throws {
+  @Test func testPolymorphicEnumValue() throws {
     // given
     let json = #"""
     {
@@ -28,13 +29,13 @@ class PolymorphicEnumDecodableTests: XCTestCase {
     // then
     switch result {
     case .callout(let value):
-      XCTAssertEqual(value.type, .callout)
+      #expect(value.type == .callout)
     default:
-      XCTFail("Invalid type")
+      Issue.record("Invalid type")
     }
   }
 
-  func testPolymorphicEnumDecodableArrayValue() throws {
+  @Test func testPolymorphicEnumDecodableArrayValue() throws {
     // given
     let json = #"""
     [
@@ -60,15 +61,15 @@ class PolymorphicEnumDecodableTests: XCTestCase {
 
     // then
     if case .callout(let value) = result[0] {
-      XCTAssertEqual(value.type, .callout)
+      #expect(value.type == .callout)
     }
     if case .dismissibleCallout(let value) = result[1] {
-      XCTAssertEqual(value.type, .dismissibleCallout)
-      XCTAssertEqual(value.key, "hi")
+      #expect(value.type == .dismissibleCallout)
+      #expect(value.key == "hi")
     }
     if case .undefinedCallout(let value) = result[2] {
-      XCTAssertEqual(value.type, .undefinedCallout)
-      XCTAssertEqual(value.description, "test")
+      #expect(value.type == .undefinedCallout)
+      #expect(value.description == "test")
     }
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-final class LossyOptionalPolymorphicValueTests: XCTestCase {
+struct LossyOptionalPolymorphicValueTests {
 
-  func testEncodingLossyOptionalPolymorphicValue() throws {
+  @Test func testEncodingLossyOptionalPolymorphicValue() throws {
     // given
     let response = LossyOptionalDummyResponse(
       notice1: DummyCallout(
@@ -39,11 +40,11 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
     let data = try encoder.encode(response)
 
     // then - notice2 (nil) is omitted, matching Apple's default Codable behavior
-    let jsonString = try XCTUnwrap(String(bytes: data, encoding: .utf8))
-    XCTAssertEqual(jsonString, expectResult)
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == expectResult)
   }
 
-  func testDecodingLossyOptionalPolymorphicValue() throws {
+  @Test func testDecodingLossyOptionalPolymorphicValue() throws {
     // given
     let jsonData = #"""
     {
@@ -59,11 +60,11 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
     let result = try JSONDecoder().decode(LossyOptionalDummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertNil(result.notice1)
-    XCTAssertEqual(result.notice2?.type, .callout)
+    #expect(result.notice1 == nil)
+    #expect(result.notice2?.type == .callout)
   }
 
-  func testDecodingEncodingLossyOptionalPolymorphicValue() throws {
+  @Test func testDecodingEncodingLossyOptionalPolymorphicValue() throws {
     // given
     let json = #"""
     {
@@ -76,8 +77,8 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
     let result = try JSONDecoder().decode(LossyOptionalDummyResponse.self, from: Data(json.utf8))
 
     // then
-    XCTAssertNil(result.notice1)
-    XCTAssertNil(result.notice2)
+    #expect(result.notice1 == nil)
+    #expect(result.notice2 == nil)
 
     // when
     let encoder = JSONEncoder()
@@ -86,13 +87,13 @@ final class LossyOptionalPolymorphicValueTests: XCTestCase {
 
     // then - all nil values are omitted, producing an empty object
     let expectResult = "{\n\n}"
-    let jsonString = try XCTUnwrap(String(bytes: data, encoding: .utf8))
-    XCTAssertEqual(jsonString, expectResult)
+    let jsonString = try #require(String(bytes: data, encoding: .utf8))
+    #expect(jsonString == expectResult)
   }
 }
 
 extension LossyOptionalPolymorphicValueTests {
-  func testDecodingOnlyValue() throws {
+  @Test func testDecodingOnlyValue() throws {
     // given
     let jsonData = #"""
     {
@@ -112,8 +113,8 @@ extension LossyOptionalPolymorphicValueTests {
     )
 
     // then
-    XCTAssertNil(result.notice1)
-    XCTAssertEqual(result.notice2?.type, .callout)
-    XCTAssertNil(result.notice3)
+    #expect(result.notice1 == nil)
+    #expect(result.notice2?.type == .callout)
+    #expect(result.notice3 == nil)
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueTests.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import XCTest
+import Testing
+import Foundation
 
 import KarrotCodableKit
 
-class PolymorphicValueTests: XCTestCase {
+struct PolymorphicValueTests {
 
-  func testEncodingPolymorphicValue() throws {
+  @Test func testEncodingPolymorphicValue() throws {
     // given
     let response = DummyResponse(
       notice: DummyCallout(type: .callout, title: nil, description: "test", icon: "test_icon"),
@@ -62,10 +63,10 @@ class PolymorphicValueTests: XCTestCase {
 
     // then
     let jsonString = String(decoding: data, as: UTF8.self)
-    XCTAssertEqual(jsonString, expectResult)
+    #expect(jsonString == expectResult)
   }
 
-  func testDecodingPolymorphicValue() throws {
+  @Test func testDecodingPolymorphicValue() throws {
     // given
     let jsonData = #"""
     {
@@ -99,14 +100,14 @@ class PolymorphicValueTests: XCTestCase {
     let result = try JSONDecoder().decode(DummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertEqual(result.notice.type, .callout)
-    XCTAssertEqual(result.notices.count, 3)
-    XCTAssertEqual(result.notices[0].type, .actionableCallout)
-    XCTAssertEqual(result.notices[1].type, .dismissibleCallout)
-    XCTAssertEqual(result.notices[2].type, .undefinedCallout)
+    #expect(result.notice.type == .callout)
+    #expect(result.notices.count == 3)
+    #expect(result.notices[0].type == .actionableCallout)
+    #expect(result.notices[1].type == .dismissibleCallout)
+    #expect(result.notices[2].type == .undefinedCallout)
   }
 
-  func testDecodingUndefinedPolymorphicValue() throws {
+  @Test func testDecodingUndefinedPolymorphicValue() throws {
     // given
     let jsonData = #"""
     {
@@ -128,14 +129,14 @@ class PolymorphicValueTests: XCTestCase {
     let result = try JSONDecoder().decode(DummyResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertEqual(result.notice.type, .undefinedCallout)
-    XCTAssertEqual(result.notices.count, 1)
-    XCTAssertEqual(result.notices[0].type, .undefinedCallout)
+    #expect(result.notice.type == .undefinedCallout)
+    #expect(result.notices.count == 1)
+    #expect(result.notices[0].type == .undefinedCallout)
   }
 }
 
 extension PolymorphicValueTests {
-  func testDecodingOnlyValue() throws {
+  @Test func testDecodingOnlyValue() throws {
     // given
     let jsonData = #"""
     {
@@ -169,10 +170,10 @@ extension PolymorphicValueTests {
     let result = try JSONDecoder().decode(DummyDecodableResponse.self, from: Data(jsonData.utf8))
 
     // then
-    XCTAssertEqual(result.notice.type, .callout)
-    XCTAssertEqual(result.notices.count, 3)
-    XCTAssertEqual(result.notices[0].type, .actionableCallout)
-    XCTAssertEqual(result.notices[1].type, .dismissibleCallout)
-    XCTAssertEqual(result.notices[2].type, .undefinedCallout)
+    #expect(result.notice.type == .callout)
+    #expect(result.notices.count == 3)
+    #expect(result.notices[0].type == .actionableCallout)
+    #expect(result.notices[1].type == .dismissibleCallout)
+    #expect(result.notices[2].type == .undefinedCallout)
   }
 }

--- a/Tests/KarrotCodableMacrosTests/Extenstions/StringSnakeCaseTests.swift
+++ b/Tests/KarrotCodableMacrosTests/Extenstions/StringSnakeCaseTests.swift
@@ -14,12 +14,12 @@
 
 import Foundation
 
-import XCTest
+import Testing
 
 @testable import KarrotCodableKitMacros
 
-final class StringSnakeCaseTests: XCTestCase {
-  func test_convert_to_snake_case() {
+struct StringSnakeCaseTests {
+  @Test func test_convert_to_snake_case() {
     // given
     let toSnakeCaseTests: [(camelCase: String, snake_case: String)] = [
       ("simpleOneTwo", "simple_one_two"),
@@ -58,7 +58,7 @@ final class StringSnakeCaseTests: XCTestCase {
       let expected = test.camelCase.toSnakeCase
 
       // then
-      XCTAssertEqual(test.snake_case, expected)
+      #expect(test.snake_case == expected)
     }
   }
 }


### PR DESCRIPTION
## 배경

테스트 스위트가 두 프레임워크로 나뉘어 있었습니다: **XCTest 42개 + swift-testing 26개.** 진행 중이던 이관을 마무리해 런타임 테스트가 단일 프레임워크(swift-testing)를 쓰도록 통일합니다.

```text
이전 · 총 68 파일                              이후 · 총 68 파일
┌───────────────────────────┐                 ┌───────────────────────────┐
│ XCTest         42          │ ──30 파일 이관─▶ │ swift-testing   56         │
│ swift-testing  26          │ ───────────────▶ │ XCTest          12         │ (매크로 확장 전용)
└───────────────────────────┘                 └───────────────────────────┘
                               └12 파일 유지─────▶ (assertMacroExpansion)
```

## 변경사항

순수 런타임 XCTest **30개 파일**을 swift-testing 으로 이관합니다. 매크로 확장 테스트 **12개**는 `SwiftSyntaxMacrosTestSupport.assertMacroExpansion` 이 XCTest 기반이라 **의도적으로 유지**합니다.

변환 규칙(1:1):

| XCTest | swift-testing |
|---|---|
| `import XCTest` | `import Testing` (+ 필요 시 `import Foundation`) |
| `final class X: XCTestCase {` | `struct X {` |
| `func testFoo()` | `@Test func testFoo()` |
| `XCTAssertEqual(a, b)` | `#expect(a == b)` |
| `XCTAssertEqual(a, b, accuracy: t)` | `#expect(abs(a - b) < t)` |
| `XCTAssertNil(a)` / `XCTAssertTrue(a)` | `#expect(a == nil)` / `#expect(a)` |
| `XCTAssertThrowsError(try f())` | `#expect(throws: (any Error).self) { try f() }` |
| `try XCTUnwrap(x)` | `try #require(x)` |
| `XCTFail("msg")` | `Issue.record("msg")` |

실제 변환 예시:

```swift
// before
import XCTest
import KarrotCodableKit

final class DefaultTrueTests: XCTestCase {
  func testDecodingKeyNotPresentDefaultsToTrue() throws {
    let jsonData = #"{}"#.data(using: .utf8)!
    let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
    XCTAssertEqual(fixture.truthy, true)
  }
}
```

```swift
// after
import Testing
import Foundation
import KarrotCodableKit

struct DefaultTrueTests {
  @Test func testDecodingKeyNotPresentDefaultsToTrue() throws {
    let jsonData = #"{}"#.data(using: .utf8)!
    let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
    #expect(fixture.truthy == true)
  }
}
```

> `import Foundation` 은 XCTest 가 암묵 재노출하던 `Data`/`JSONDecoder` 를 위해 필요한 파일에만 명시적으로 추가했습니다.

## 변경 파일 (30개, 그룹별)

- **AnyCodable(3)**: `AnyCodableTests`, `AnyDecodableTests`, `AnyEncodableTests`
- **BetterCodable/Defaults(9)**: `DefaulEmptyDictionaryTests`, `DefaultCodableTests`, `DefaultEmptyArrayTests`, `DefaultEmptyStringTests`, `DefaultFalseTests`, `DefaultTrueTests`, `DefaultZeroDoubleTests`, `DefaultZeroFloatTests`, `DefaultZeroIntTests`
- **BetterCodable/LosslessValue(3)**: `LosslessArrayTests`, `LosslessCustomValueTests`, `LosslessValueTests`
- **BetterCodable/LossyValue(3)**: `LossyArrayTests`, `LossyDictionaryTests`, `LossyOptionalTests`
- **BetterCodable/DateValue·DataValue(3)**: `DateValueTests`, `OptionalDateValueTests`, `DataValueTests`
- **PolymorphicCodable(6)**: `DefaultEmptyPolymorphicArrayValueTests`, `PolymorphicLossyArrayValueTests`, `PolymorphicEnumCodableTests`, `PolymorphicEnumDecodableTests`, `LossyOptionalPolymorphicValueTests`, `PolymorphicValueTests`
- **기타(3)**: `RawRepresentableTests`, `Encodable+ToDictionaryTests`, `StringSnakeCaseTests`

_30 files changed, +475 / −454_

## 변경했을 때의 트레이드 오프

- **대형 단일 PR(30 파일)** → 리뷰 부담은 크지만 프레임워크 통일 이득이 큽니다. (서브시스템별 분할 커밋도 가능하나 기계적 변환이라 단일 커밋으로 진행)
- **완전 단일화는 아닙니다** — 매크로 확장 테스트 12개는 XCTest 로 남습니다(`assertMacroExpansion` 제약). 추후 `SwiftSyntaxMacrosGenericTestSupport` 로의 이관은 별건 후속 과제.
- **`test` 접두사 유지** — swift-testing 은 접두사가 불필요하지만, diff/네이밍 변경 리스크를 줄이기 위해 이름은 그대로 두고 `@Test` 만 부착했습니다.
- **부동소수 비교**는 `accuracy:` 가 swift-testing 에 없어 `#expect(abs(a - b) < t)` 로 옮겼습니다 — 허용 오차 의미를 보존합니다.

## 테스트 방법

- `swift test -c debug` / `swift test -c release` — 전부 통과(실패 0).
- **전체 테스트 수 360개로 보존**: 기준 166 swift-testing + 194 XCTest → 286 swift-testing + 74 XCTest. 유실 0.
- 이관 후 `import XCTest` 잔존 파일은 **정확히 12개**이며 전부 `assertMacroExpansion` 사용(매크로 확장 스위트)임을 확인.

## 기타

- 기계적·동작 보존 마이그레이션이라 각 테스트의 assertion 의미는 그대로입니다.
- 파일명 오타(`DefaulEmptyDictionaryTests`, 디렉터리 `Extenstions/`)는 범위를 넘지 않도록 이 PR 에서 건드리지 않았습니다(별건).

