### PR TITLE
chore: expand swift-syntax version range to 509.0.0..<604.0.0 and bump CI to Xcode 26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        xcode: ['16.4']
+        xcode: ['26.3']
         config: ['debug', 'release']
 
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"603.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"604.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
## Background (Required)
- The swift-syntax dependency upper bound was capped below `602.0.0`, so KarrotCodableKit could not be used in dependency graphs that resolve swift-syntax 602.x (Swift 6.2) or 603.x (Swift 6.3).
- CI was pinned to Xcode 16.4 (Swift 6.1), which predates the newer swift-syntax lines.

## Changes
- Widen the swift-syntax version range from `"509.0.0"..<"602.0.0"` to `"509.0.0"..<"604.0.0"` in `Package.swift`, allowing the 602.x (Swift 6.2) and 603.x (Swift 6.3) lines.
- Bump the CI test matrix from Xcode 16.4 (Swift 6.1) to Xcode 26.3 (Swift 6.3), which is available on the `macos-15` runner image.

## Testing Methods
- Resolved swift-syntax to `603.0.2` (the newest version in the widened range) and ran the full suite locally on Swift 6.3.1 — the same Swift line as the new CI toolchain:
  - `swift test` (debug): 194 XCTest + 171 Swift Testing tests, 0 failures — macro expansion tests (exact-string assertions) all pass against 603.
  - `swift test -c release`: all tests pass.
- Also verified against `602.0.0` earlier in this branch: debug and release suites both pass.
- Since no `Package.resolved` is committed, this PR's CI resolves `603.0.2` and validates the new upper bound directly.

## Review Notes
- The `check-macro-compatibility` job pins its own version list (509.0.0–601.0.1), so it still guards the lower end of the range and is unaffected by the upper-bound change.
- swift-syntax `602.0.0`/`603.0.2` both declare `swift-tools-version: 5.9`, so SwiftPM on older toolchains will also resolve them; consumers stuck on older Xcode can pin a lower version if needed.

Ref: IOS-4896

https://claude.ai/code/session_01G5CQ6RqYaohJ4yPkDksNc7
