### PR TITLE
style: apply swiftformat across the codebase

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,36 +10,36 @@ let package = Package(
   products: [
     .library(
       name: "KarrotCodableKit",
-      targets: ["KarrotCodableKit"]
-    ),
+      targets: ["KarrotCodableKit"],
+    )
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"604.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"604.0.0")
   ],
   targets: [
     .target(
       name: "KarrotCodableKit",
-      dependencies: ["KarrotCodableKitMacros"]
+      dependencies: ["KarrotCodableKitMacros"],
     ),
     .macro(
       name: "KarrotCodableKitMacros",
       dependencies: [
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-      ]
+      ],
     ),
     .testTarget(
       name: "KarrotCodableKitTests",
       dependencies: [
-        "KarrotCodableKit",
-      ]
+        "KarrotCodableKit"
+      ],
     ),
     .testTarget(
       name: "KarrotCodableMacrosTests",
       dependencies: [
         "KarrotCodableKitMacros",
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
-      ]
+      ],
     ),
-  ]
+  ],
 )

--- a/Sources/KarrotCodableKit/AnyCodable/AnyCodable.swift
+++ b/Sources/KarrotCodableKit/AnyCodable/AnyCodable.swift
@@ -7,19 +7,17 @@
 
 import Foundation
 
-/**
- A type-erased `Codable` value.
-
- The `AnyCodable` type forwards encoding and decoding responsibilities
- to an underlying value, hiding its specific underlying type.
-
- You can encode or decode mixed-type values in dictionaries
- and other collections that require `Encodable` or `Decodable` conformance
- by declaring their contained type to be `AnyCodable`.
-
- - SeeAlso: `AnyEncodable`
- - SeeAlso: `AnyDecodable`
- */
+/// A type-erased `Codable` value.
+///
+/// The `AnyCodable` type forwards encoding and decoding responsibilities
+/// to an underlying value, hiding its specific underlying type.
+///
+/// You can encode or decode mixed-type values in dictionaries
+/// and other collections that require `Encodable` or `Decodable` conformance
+/// by declaring their contained type to be `AnyCodable`.
+///
+/// - SeeAlso: `AnyEncodable`
+/// - SeeAlso: `AnyDecodable`
 @frozen
 public struct AnyCodable: Codable {
   public let value: Any
@@ -35,47 +33,47 @@ extension AnyCodable: Equatable {
   public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
     switch (lhs.value, rhs.value) {
     case is (Void, Void):
-      return true
+      true
     case (let lhs as Bool, let rhs as Bool):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int, let rhs as Int):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int8, let rhs as Int8):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int16, let rhs as Int16):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int32, let rhs as Int32):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int64, let rhs as Int64):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt, let rhs as UInt):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt8, let rhs as UInt8):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt16, let rhs as UInt16):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt32, let rhs as UInt32):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt64, let rhs as UInt64):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Float, let rhs as Float):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Double, let rhs as Double):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as String, let rhs as String):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as [String: AnyCodable], let rhs as [String: AnyCodable]):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as [AnyCodable], let rhs as [AnyCodable]):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as [String: Any], let rhs as [String: Any]):
-      return NSDictionary(dictionary: lhs) == NSDictionary(dictionary: rhs)
+      NSDictionary(dictionary: lhs) == NSDictionary(dictionary: rhs)
     case (let lhs as [Any], let rhs as [Any]):
-      return NSArray(array: lhs) == NSArray(array: rhs)
+      NSArray(array: lhs) == NSArray(array: rhs)
     case is (NSNull, NSNull):
-      return true
+      true
     default:
-      return false
+      false
     }
   }
 }
@@ -84,11 +82,11 @@ extension AnyCodable: CustomStringConvertible {
   public var description: String {
     switch value {
     case is Void:
-      return String(describing: nil as Any?)
+      String(describing: nil as Any?)
     case let value as CustomStringConvertible:
-      return value.description
+      value.description
     default:
-      return String(describing: value)
+      String(describing: value)
     }
   }
 }
@@ -97,9 +95,9 @@ extension AnyCodable: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch value {
     case let value as CustomDebugStringConvertible:
-      return "AnyCodable(\(value.debugDescription))"
+      "AnyCodable(\(value.debugDescription))"
     default:
-      return "AnyCodable(\(description))"
+      "AnyCodable(\(description))"
     }
   }
 }
@@ -112,7 +110,6 @@ extension AnyCodable: ExpressibleByStringLiteral {}
 extension AnyCodable: ExpressibleByStringInterpolation {}
 extension AnyCodable: ExpressibleByArrayLiteral {}
 extension AnyCodable: ExpressibleByDictionaryLiteral {}
-
 
 extension AnyCodable: Hashable {
   public func hash(into hasher: inout Hasher) {

--- a/Sources/KarrotCodableKit/AnyCodable/AnyDecodable.swift
+++ b/Sources/KarrotCodableKit/AnyCodable/AnyDecodable.swift
@@ -7,35 +7,33 @@
 
 import Foundation
 
-/**
- A type-erased `Decodable` value.
-
- The `AnyDecodable` type forwards decoding responsibilities
- to an underlying value, hiding its specific underlying type.
-
- You can decode mixed-type values in dictionaries
- and other collections that require `Decodable` conformance
- by declaring their contained type to be `AnyDecodable`:
-
-     let json = """
-     {
-         "boolean": true,
-         "integer": 42,
-         "double": 3.141592653589793,
-         "string": "string",
-         "array": [1, 2, 3],
-         "nested": {
-             "a": "alpha",
-             "b": "bravo",
-             "c": "charlie"
-         },
-         "null": null
-     }
-     """.data(using: .utf8)!
-
-     let decoder = JSONDecoder()
-     let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
- */
+/// A type-erased `Decodable` value.
+///
+/// The `AnyDecodable` type forwards decoding responsibilities
+/// to an underlying value, hiding its specific underlying type.
+///
+/// You can decode mixed-type values in dictionaries
+/// and other collections that require `Decodable` conformance
+/// by declaring their contained type to be `AnyDecodable`:
+///
+///    let json = """
+///    {
+///        "boolean": true,
+///        "integer": 42,
+///        "double": 3.141592653589793,
+///        "string": "string",
+///        "array": [1, 2, 3],
+///        "nested": {
+///            "a": "alpha",
+///            "b": "bravo",
+///            "c": "charlie"
+///        },
+///        "null": null
+///    }
+///    """.data(using: .utf8)!
+///
+///    let decoder = JSONDecoder()
+///    let dictionary = try! decoder.decode([String: AnyDecodable].self, from: json)
 @frozen
 public struct AnyDecodable: Decodable {
   public let value: Any
@@ -80,7 +78,7 @@ extension _AnyDecodable {
     } else {
       throw DecodingError.dataCorruptedError(
         in: container,
-        debugDescription: "AnyDecodable value cannot be decoded"
+        debugDescription: "AnyDecodable value cannot be decoded",
       )
     }
   }
@@ -135,11 +133,11 @@ extension AnyDecodable: CustomStringConvertible {
   public var description: String {
     switch value {
     case is Void:
-      return String(describing: nil as Any?)
+      String(describing: nil as Any?)
     case let value as CustomStringConvertible:
-      return value.description
+      value.description
     default:
-      return String(describing: value)
+      String(describing: value)
     }
   }
 }
@@ -148,9 +146,9 @@ extension AnyDecodable: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch value {
     case let value as CustomDebugStringConvertible:
-      return "AnyDecodable(\(value.debugDescription))"
+      "AnyDecodable(\(value.debugDescription))"
     default:
-      return "AnyDecodable(\(description))"
+      "AnyDecodable(\(description))"
     }
   }
 }

--- a/Sources/KarrotCodableKit/AnyCodable/AnyEncodable.swift
+++ b/Sources/KarrotCodableKit/AnyCodable/AnyEncodable.swift
@@ -7,33 +7,31 @@
 
 import Foundation
 
-/**
- A type-erased `Encodable` value.
-
- The `AnyEncodable` type forwards encoding responsibilities
- to an underlying value, hiding its specific underlying type.
-
- You can encode mixed-type values in dictionaries
- and other collections that require `Encodable` conformance
- by declaring their contained type to be `AnyEncodable`:
-
-     let dictionary: [String: AnyEncodable] = [
-         "boolean": true,
-         "integer": 42,
-         "double": 3.141592653589793,
-         "string": "string",
-         "array": [1, 2, 3],
-         "nested": [
-             "a": "alpha",
-             "b": "bravo",
-             "c": "charlie"
-         ],
-         "null": nil
-     ]
-
-     let encoder = JSONEncoder()
-     let json = try! encoder.encode(dictionary)
- */
+/// A type-erased `Encodable` value.
+///
+/// The `AnyEncodable` type forwards encoding responsibilities
+/// to an underlying value, hiding its specific underlying type.
+///
+/// You can encode mixed-type values in dictionaries
+/// and other collections that require `Encodable` conformance
+/// by declaring their contained type to be `AnyEncodable`:
+///
+///    let dictionary: [String: AnyEncodable] = [
+///        "boolean": true,
+///        "integer": 42,
+///        "double": 3.141592653589793,
+///        "string": "string",
+///        "array": [1, 2, 3],
+///        "nested": [
+///            "a": "alpha",
+///            "b": "bravo",
+///            "c": "charlie"
+///        ],
+///        "null": nil
+///    ]
+///
+///    let encoder = JSONEncoder()
+///    let json = try! encoder.encode(dictionary)
 @frozen
 public struct AnyEncodable: Encodable {
   public let value: Any
@@ -109,7 +107,7 @@ extension _AnyEncodable {
     default:
       let context = EncodingError.Context(
         codingPath: container.codingPath,
-        debugDescription: "AnyEncodable value cannot be encoded"
+        debugDescription: "AnyEncodable value cannot be encoded",
       )
       throw EncodingError.invalidValue(value, context)
     }
@@ -143,7 +141,7 @@ extension _AnyEncodable {
     default:
       let context = EncodingError.Context(
         codingPath: container.codingPath,
-        debugDescription: "NSNumber cannot be encoded because its type is not handled"
+        debugDescription: "NSNumber cannot be encoded because its type is not handled",
       )
       throw EncodingError.invalidValue(nsnumber, context)
     }
@@ -155,41 +153,41 @@ extension AnyEncodable: Equatable {
   public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
     switch (lhs.value, rhs.value) {
     case is (Void, Void):
-      return true
+      true
     case (let lhs as Bool, let rhs as Bool):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int, let rhs as Int):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int8, let rhs as Int8):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int16, let rhs as Int16):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int32, let rhs as Int32):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Int64, let rhs as Int64):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt, let rhs as UInt):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt8, let rhs as UInt8):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt16, let rhs as UInt16):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt32, let rhs as UInt32):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as UInt64, let rhs as UInt64):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Float, let rhs as Float):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as Double, let rhs as Double):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as String, let rhs as String):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as [String: AnyEncodable], let rhs as [String: AnyEncodable]):
-      return lhs == rhs
+      lhs == rhs
     case (let lhs as [AnyEncodable], let rhs as [AnyEncodable]):
-      return lhs == rhs
+      lhs == rhs
     default:
-      return false
+      false
     }
   }
 }
@@ -198,11 +196,11 @@ extension AnyEncodable: CustomStringConvertible {
   public var description: String {
     switch value {
     case is Void:
-      return String(describing: nil as Any?)
+      String(describing: nil as Any?)
     case let value as CustomStringConvertible:
-      return value.description
+      value.description
     default:
-      return String(describing: value)
+      String(describing: value)
     }
   }
 }
@@ -211,9 +209,9 @@ extension AnyEncodable: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch value {
     case let value as CustomDebugStringConvertible:
-      return "AnyEncodable(\(value.debugDescription))"
+      "AnyEncodable(\(value.debugDescription))"
     default:
-      return "AnyEncodable(\(description))"
+      "AnyEncodable(\(description))"
     }
   }
 }

--- a/Sources/KarrotCodableKit/BetterCodable/DataValue/DataValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DataValue/DataValue.swift
@@ -29,7 +29,7 @@ public struct DataValue<Coder: DataValueCodableStrategy> {
 
   public init(wrappedValue: Coder.DataType) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: Coder.DataType, outcome: ResilientDecodingOutcome) {
@@ -48,8 +48,8 @@ extension DataValue: Decodable {
   public init(from decoder: Decoder) throws {
     do {
       let stringValue = try String(from: decoder)
-      self.wrappedValue = try Coder.decode(stringValue)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try Coder.decode(stringValue)
+      outcome = .decodedSuccessfully
     } catch {
       #if DEBUG
       decoder.reportError(error)

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/DateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/DateValue.swift
@@ -29,7 +29,7 @@ public struct DateValue<Formatter: DateValueCodableStrategy> {
 
   public init(wrappedValue: Date) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: Date, outcome: ResilientDecodingOutcome) {
@@ -48,8 +48,8 @@ extension DateValue: Decodable where Formatter.RawValue: Decodable {
   public init(from decoder: Decoder) throws {
     do {
       let value = try Formatter.RawValue(from: decoder)
-      self.wrappedValue = try Formatter.decode(value)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try Formatter.decode(value)
+      outcome = .decodedSuccessfully
     } catch {
       #if DEBUG
       decoder.reportError(error)

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/KeyedEncodingContainer+OptionalDateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/KeyedEncodingContainer+OptionalDateValue.swift
@@ -16,7 +16,7 @@ extension KeyedEncodingContainer {
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
   public mutating func encode<T>(
     _ value: OptionalDateValue<T>,
-    forKey key: Key
+    forKey key: Key,
   ) throws where T.RawValue: Encodable {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/OptionalDateValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/OptionalDateValue.swift
@@ -30,7 +30,7 @@ public struct OptionalDateValue<Formatter: OptionalDateValueCodableStrategy> {
 
   public init(wrappedValue: Date?) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: Date?, outcome: ResilientDecodingOutcome) {
@@ -50,8 +50,8 @@ extension OptionalDateValue: Decodable where Formatter.RawValue: Decodable {
     do {
       let value = try Formatter.RawValue(from: decoder)
       do {
-        self.wrappedValue = try Formatter.decode(value)
-        self.outcome = .decodedSuccessfully
+        wrappedValue = try Formatter.decode(value)
+        outcome = .decodedSuccessfully
       } catch {
         #if DEBUG
         decoder.reportError(error)
@@ -60,12 +60,12 @@ extension OptionalDateValue: Decodable where Formatter.RawValue: Decodable {
       }
 
     } catch DecodingError.keyNotFound {
-      self.wrappedValue = nil
-      self.outcome = .keyNotFound
+      wrappedValue = nil
+      outcome = .keyNotFound
 
     } catch DecodingError.valueNotFound(let rawType, _) where rawType == Formatter.RawValue.self {
-      self.wrappedValue = nil
-      self.outcome = .valueWasNil
+      wrappedValue = nil
+      outcome = .valueWasNil
 
     } catch {
       #if DEBUG
@@ -100,7 +100,7 @@ extension OptionalDateValue: Sendable where Formatter.RawValue: Sendable {}
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: OptionalDateValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> OptionalDateValue<T> where T.RawValue: Decodable {
     // Check if the key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601Strategy.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601Strategy.swift
@@ -21,7 +21,7 @@ public struct ISO8601Strategy: DateValueCodableStrategy {
       throw DecodingError.dataCorrupted(
         DecodingError.Context(
           codingPath: [],
-          debugDescription: "\"\(value)\" is invalid date format!"
+          debugDescription: "\"\(value)\" is invalid date format!",
         )
       )
     }

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601WithFractionalSecondsStrategy.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/ISO8601WithFractionalSecondsStrategy.swift
@@ -27,7 +27,7 @@ public struct ISO8601WithFractionalSecondsStrategy: DateValueCodableStrategy {
       throw DecodingError.dataCorrupted(
         DecodingError.Context(
           codingPath: [],
-          debugDescription: "\"\(value)\" is invalid date format!"
+          debugDescription: "\"\(value)\" is invalid date format!",
         )
       )
     }

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/RFC3339NanoStrategy.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/RFC3339NanoStrategy.swift
@@ -45,7 +45,7 @@ public struct RFC3339NanoStrategy: DateValueCodableStrategy {
     throw DecodingError.dataCorrupted(
       DecodingError.Context(
         codingPath: [],
-        debugDescription: "\"\(value)\" is invalid date format!"
+        debugDescription: "\"\(value)\" is invalid date format!",
       )
     )
   }

--- a/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/RFC3339Strategy.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/DateValue/Strategy/RFC3339Strategy.swift
@@ -31,7 +31,7 @@ public struct RFC3339Strategy: DateValueCodableStrategy {
       throw DecodingError.dataCorrupted(
         DecodingError.Context(
           codingPath: [],
-          debugDescription: "\"\(value)\" is invalid date format!"
+          debugDescription: "\"\(value)\" is invalid date format!",
         )
       )
     }

--- a/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultCodable.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultCodable.swift
@@ -40,7 +40,7 @@ public struct DefaultCodable<Default: DefaultCodableStrategy> {
 
   public init(wrappedValue: Default.DefaultValue) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: Default.DefaultValue, outcome: ResilientDecodingOutcome) {
@@ -58,7 +58,7 @@ public struct DefaultCodable<Default: DefaultCodableStrategy> {
 extension DefaultCodable where Default.Type == Default.DefaultValue.Type {
   public init(wrappedValue: Default) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 }
 

--- a/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultEmptyDictionary.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/Defaults/DefaultEmptyDictionary.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct DefaultEmptyDictionaryStrategy<
   Key: Decodable & Hashable,
-  Value: Decodable
+  Value: Decodable,
 >: DefaultCodableStrategy {
   public static var defaultValue: [Key: Value] { [:] }
 }
@@ -20,5 +20,5 @@ public struct DefaultEmptyDictionaryStrategy<
 /// to decode the container.
 public typealias DefaultEmptyDictionary<
   Key: Decodable & Hashable,
-  Value: Decodable
+  Value: Decodable,
 > = DefaultCodable<DefaultEmptyDictionaryStrategy<Key, Value>>

--- a/Sources/KarrotCodableKit/BetterCodable/Defaults/Extenstions/KeyedDecodingContainer+DefaultCodable.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/Defaults/Extenstions/KeyedDecodingContainer+DefaultCodable.swift
@@ -166,7 +166,7 @@ extension KeyedDecodingContainer {
       decoder?.reportError(error)
       return DefaultCodable(
         wrappedValue: P.defaultValue,
-        outcome: .recoveredFrom(error, wasReported: decoder != nil)
+        outcome: .recoveredFrom(error, wasReported: decoder != nil),
       )
       #else
       return DefaultCodable(wrappedValue: P.defaultValue)
@@ -179,7 +179,7 @@ extension KeyedDecodingContainer {
       decoder?.reportError(error)
       return DefaultCodable(
         wrappedValue: P.defaultValue,
-        outcome: .recoveredFrom(error, wasReported: decoder != nil)
+        outcome: .recoveredFrom(error, wasReported: decoder != nil),
       )
       #else
       return DefaultCodable(wrappedValue: P.defaultValue)

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/KeyedEncodingContainer+OptionalLosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/KeyedEncodingContainer+OptionalLosslessValue.swift
@@ -14,10 +14,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
-  public mutating func encode<T>(
-    _ value: OptionalLosslessValueCodable<T>,
-    forKey key: Key
-  ) throws where T: LosslessDecodingStrategy {
+  public mutating func encode(
+    _ value: OptionalLosslessValueCodable<some LosslessDecodingStrategy>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessArray.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessArray.swift
@@ -22,7 +22,7 @@ public struct LosslessArray<T: LosslessStringCodable> {
 
   public init(wrappedValue: [T]) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: [T], outcome: ResilientDecodingOutcome) {
@@ -43,9 +43,9 @@ extension LosslessArray: Decodable where T: Decodable {
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
 
-    var elements: [T] = []
+    var elements = [T]()
     #if DEBUG
-    var results: [Result<T, Error>] = []
+    var results = [Result<T, Error>]()
     #endif
 
     while !container.isAtEnd {

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/LosslessValue.swift
@@ -35,14 +35,14 @@ public struct LosslessValueCodable<Strategy: LosslessDecodingStrategy>: Codable 
 
   public init(wrappedValue: Strategy.Value) {
     self.wrappedValue = wrappedValue
-    self.type = Strategy.Value.self
-    self.outcome = .decodedSuccessfully
+    type = Strategy.Value.self
+    outcome = .decodedSuccessfully
   }
 
   init(
     wrappedValue: Strategy.Value,
     outcome: ResilientDecodingOutcome,
-    type: LosslessStringCodable.Type
+    type: LosslessStringCodable.Type,
   ) {
     self.wrappedValue = wrappedValue
     self.outcome = outcome
@@ -57,9 +57,9 @@ public struct LosslessValueCodable<Strategy: LosslessDecodingStrategy>: Codable 
 
   public init(from decoder: Decoder) throws {
     do {
-      self.wrappedValue = try Strategy.Value(from: decoder)
-      self.type = Strategy.Value.self
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try Strategy.Value(from: decoder)
+      type = Strategy.Value.self
+      outcome = .decodedSuccessfully
     } catch {
       guard
         let rawValue = Strategy.losslessDecodableTypes.lazy.compactMap({ $0(decoder) }).first,
@@ -71,9 +71,9 @@ public struct LosslessValueCodable<Strategy: LosslessDecodingStrategy>: Codable 
         throw error
       }
 
-      self.wrappedValue = value
-      self.type = Swift.type(of: rawValue)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = value
+      type = Swift.type(of: rawValue)
+      outcome = .decodedSuccessfully
     }
   }
 

--- a/Sources/KarrotCodableKit/BetterCodable/LosslessValue/OptionalLosslessValue.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LosslessValue/OptionalLosslessValue.swift
@@ -24,14 +24,14 @@ public struct OptionalLosslessValueCodable<Strategy: LosslessDecodingStrategy>: 
 
   public init(wrappedValue: Strategy.Value?) {
     self.wrappedValue = wrappedValue
-    self.type = wrappedValue.map { Swift.type(of: $0) }
-    self.outcome = wrappedValue == nil ? .valueWasNil : .decodedSuccessfully
+    type = wrappedValue.map { Swift.type(of: $0) }
+    outcome = wrappedValue == nil ? .valueWasNil : .decodedSuccessfully
   }
 
   init(
     wrappedValue: Strategy.Value?,
     outcome: ResilientDecodingOutcome,
-    type: LosslessStringCodable.Type?
+    type: LosslessStringCodable.Type?,
   ) {
     self.wrappedValue = wrappedValue
     self.outcome = outcome
@@ -48,29 +48,31 @@ public struct OptionalLosslessValueCodable<Strategy: LosslessDecodingStrategy>: 
     do {
       // First, try to decode the value normally
       let value = try Strategy.Value(from: decoder)
-      self.wrappedValue = value
-      self.type = Strategy.Value.self
-      self.outcome = .decodedSuccessfully
+      wrappedValue = value
+      type = Strategy.Value.self
+      outcome = .decodedSuccessfully
 
     } catch DecodingError.valueNotFound {
       // Handle null value
-      self.wrappedValue = nil
-      self.type = nil
-      self.outcome = .valueWasNil
+      wrappedValue = nil
+      type = nil
+      outcome = .valueWasNil
 
     } catch DecodingError.keyNotFound {
       // Handle missing key
-      self.wrappedValue = nil
-      self.type = nil
-      self.outcome = .keyNotFound
+      wrappedValue = nil
+      type = nil
+      outcome = .keyNotFound
 
     } catch {
       // Try to decode using the strategy's lossless decodable types
-      if let rawValue = Strategy.losslessDecodableTypes.lazy.compactMap({ $0(decoder) }).first,
-         let value = Strategy.Value("\(rawValue)") {
-        self.wrappedValue = value
-        self.type = Swift.type(of: rawValue)
-        self.outcome = .decodedSuccessfully
+      if
+        let rawValue = Strategy.losslessDecodableTypes.lazy.compactMap({ $0(decoder) }).first,
+        let value = Strategy.Value("\(rawValue)")
+      {
+        wrappedValue = value
+        type = Swift.type(of: rawValue)
+        outcome = .decodedSuccessfully
         return
       }
 
@@ -83,9 +85,9 @@ public struct OptionalLosslessValueCodable<Strategy: LosslessDecodingStrategy>: 
         throw error
       }
 
-      self.wrappedValue = nil
-      self.type = nil
-      self.outcome = .valueWasNil
+      wrappedValue = nil
+      type = nil
+      outcome = .valueWasNil
     }
   }
 
@@ -168,7 +170,7 @@ public typealias OptionalLosslessBoolValue<
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: OptionalLosslessValueCodable<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> OptionalLosslessValueCodable<T> where T.Value: Decodable {
     guard contains(key) else {
       return OptionalLosslessValueCodable<T>(wrappedValue: nil, outcome: .keyNotFound, type: nil)

--- a/Sources/KarrotCodableKit/BetterCodable/LossyValue/KeyedEncodingContainer+LossyOptional.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LossyValue/KeyedEncodingContainer+LossyOptional.swift
@@ -18,10 +18,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as the default `nil`.
-  public mutating func encode<T>(
-    _ value: DefaultCodable<DefaultNilStrategy<T>>,
-    forKey key: Key
-  ) throws where T: Encodable {
+  public mutating func encode(
+    _ value: DefaultCodable<DefaultNilStrategy<some Encodable>>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyArray.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyArray.swift
@@ -20,7 +20,7 @@ public struct LossyArray<T> {
 
   public init(wrappedValue: [T]) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: [T], outcome: ResilientDecodingOutcome) {
@@ -46,7 +46,7 @@ extension LossyArray: Decodable where T: Decodable {
         #if DEBUG
         let context = DecodingError.Context(
           codingPath: decoder.codingPath,
-          debugDescription: "Value was nil but property is non-optional"
+          debugDescription: "Value was nil but property is non-optional",
         )
         let error = DecodingError.valueNotFound([T].self, context)
         decoder.reportError(error)
@@ -63,9 +63,9 @@ extension LossyArray: Decodable where T: Decodable {
     do {
       var container = try decoder.unkeyedContainer()
 
-      var elements: [T] = []
+      var elements = [T]()
       #if DEBUG
-      var results: [Result<T, Error>] = []
+      var results = [Result<T, Error>]()
       #endif
 
       while !container.isAtEnd {

--- a/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyDictionary.swift
+++ b/Sources/KarrotCodableKit/BetterCodable/LossyValue/LossyDictionary.swift
@@ -20,7 +20,7 @@ public struct LossyDictionary<Key: Hashable, Value> {
 
   public init(wrappedValue: [Key: Value]) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: [Key: Value], outcome: ResilientDecodingOutcome) {
@@ -42,11 +42,11 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
 
     init?(stringValue: String) {
       self.stringValue = stringValue
-      self.intValue = Int(stringValue)
+      intValue = Int(stringValue)
     }
 
     init?(intValue: Int) {
-      self.stringValue = "\(intValue)"
+      stringValue = "\(intValue)"
       self.intValue = intValue
     }
   }
@@ -57,7 +57,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
 
     public init(from decoder: Decoder) throws {
       let container = try decoder.singleValueContainer()
-      self.value = try container.decode(DecodablValue.self)
+      value = try container.decode(DecodablValue.self)
     }
   }
 
@@ -98,7 +98,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
         container: container,
         key: extractedKey.codingKey,
         originalKey: extractedKey.originalKey,
-        state: &state
+        state: &state,
       )
     }
 
@@ -125,7 +125,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
         container: container,
         key: key,
         intKey: intValue,
-        state: &state
+        state: &state,
       )
     }
 
@@ -136,7 +136,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
     container: KeyedDecodingContainer<DictionaryCodingKey>,
     key: DictionaryCodingKey,
     originalKey: String,
-    state: inout DecodingState
+    state: inout DecodingState,
   ) {
     // Safe casting - if it fails, we skip this key entirely
     guard let castKey = originalKey as? Key else { return }
@@ -161,7 +161,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
     container: KeyedDecodingContainer<DictionaryCodingKey>,
     key: DictionaryCodingKey,
     intKey: Int,
-    state: inout DecodingState
+    state: inout DecodingState,
   ) {
     // Safe casting - if it fails, we skip this key entirely
     guard let castKey = intKey as? Key else { return }
@@ -201,7 +201,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
       #if DEBUG
       let context = DecodingError.Context(
         codingPath: decoder.codingPath,
-        debugDescription: "Value was nil but property is non-optional"
+        debugDescription: "Value was nil but property is non-optional",
       )
       let error = DecodingError.valueNotFound([Key: Value].self, context)
       decoder.reportError(error)
@@ -213,18 +213,19 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
     }
 
     do {
-      let state: DecodingState = if Key.self == String.self {
-        try Self.decodeStringKeyedDictionary(from: decoder)
-      } else if Key.self == Int.self {
-        try Self.decodeIntKeyedDictionary(from: decoder)
-      } else {
-        throw DecodingError.dataCorrupted(
-          DecodingError.Context(
-            codingPath: decoder.codingPath,
-            debugDescription: "Unable to decode key type."
+      let state: DecodingState =
+        if Key.self == String.self {
+          try Self.decodeStringKeyedDictionary(from: decoder)
+        } else if Key.self == Int.self {
+          try Self.decodeIntKeyedDictionary(from: decoder)
+        } else {
+          throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+              codingPath: decoder.codingPath,
+              debugDescription: "Unable to decode key type.",
+            )
           )
-        )
-      }
+        }
 
       self = Self.createFinalResult(from: state)
     } catch {
@@ -239,7 +240,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
 
   private static func extractKeys(
     from decoder: Decoder,
-    container: KeyedDecodingContainer<DictionaryCodingKey>
+    container: KeyedDecodingContainer<DictionaryCodingKey>,
   ) throws -> [ExtractedKey] {
     // Decode a dictionary ignoring the values to decode the original keys
     // without using the `JSONDecoder.KeyDecodingStrategy`.
@@ -247,7 +248,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
 
     return zip(
       container.allKeys.sorted(by: { $0.stringValue < $1.stringValue }),
-      keys.sorted()
+      keys.sorted(),
     )
     .map { ExtractedKey(codingKey: $0, originalKey: $1) }
   }
@@ -272,7 +273,7 @@ extension LossyDictionary: Sendable where Key: Sendable, Value: Sendable {}
 extension KeyedDecodingContainer {
   public func decode<DictKey, DictValue>(
     _: LossyDictionary<DictKey, DictValue>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> LossyDictionary<DictKey, DictValue>
     where DictKey: Hashable & Decodable, DictValue: Decodable
   {
@@ -282,7 +283,7 @@ extension KeyedDecodingContainer {
       #if DEBUG
       let context = DecodingError.Context(
         codingPath: codingPath + [key],
-        debugDescription: "Key not found but property is non-optional"
+        debugDescription: "Key not found but property is non-optional",
       )
       let error = DecodingError.keyNotFound(key, context)
       let decoder = try? superDecoder(forKey: key)

--- a/Sources/KarrotCodableKit/CustomCodable/CodingKeyStyle.swift
+++ b/Sources/KarrotCodableKit/CustomCodable/CodingKeyStyle.swift
@@ -9,16 +9,14 @@
 
 import Foundation
 
-/**
- Defines the style to use when converting property names to coding keys.
-
- This enum is used with `@CustomCodable` and `@PolymorphicCodable` property wrappers
- to control how Swift property names are mapped to and from JSON keys during encoding
- and decoding processes.
-
- - Note: When used with custom codable types, this style determines the transformation
-         applied to property names when generating coding keys.
- */
+/// Defines the style to use when converting property names to coding keys.
+///
+/// This enum is used with `@CustomCodable` and `@PolymorphicCodable` property wrappers
+/// to control how Swift property names are mapped to and from JSON keys during encoding
+/// and decoding processes.
+///
+/// - Note: When used with custom codable types, this style determines the transformation
+///        applied to property names when generating coding keys.
 public enum CodingKeyStyle {
   /// Converts property name to `snake_case` and uses it as CodingKey.
   case snakeCase

--- a/Sources/KarrotCodableKit/CustomCodable/Interface/CodableKey.swift
+++ b/Sources/KarrotCodableKit/CustomCodable/Interface/CodableKey.swift
@@ -7,28 +7,26 @@
 //
 //
 
-/**
- A macro that allows customizing the key name used in CodingKeys when using `@CustomCodable`,
- `@CustomEncodable`, or `@CustomDecodable`.
-
- - Parameter name: The string value to use as the coding key name.
-   (e.g., `@CodableKey(name: "userProfileUrl")`)
-
- ## Example
-
- ```swift
- @CustomCodable(codingKeyStyle: .snakeCase)
- struct Person {
-   let name: String
-   let userAge: Int
-
-   @CodableKey(name: "userProfileUrl")
-   let userProfileURL: String
- }
- ```
- */
+/// A macro that allows customizing the key name used in CodingKeys when using `@CustomCodable`,
+/// `@CustomEncodable`, or `@CustomDecodable`.
+///
+/// - Parameter name: The string value to use as the coding key name.
+///  (e.g., `@CodableKey(name: "userProfileUrl")`)
+///
+/// ## Example
+///
+/// ```swift
+/// @CustomCodable(codingKeyStyle: .snakeCase)
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///
+///  @CodableKey(name: "userProfileUrl")
+///  let userProfileURL: String
+/// }
+/// ```
 @attached(peer)
 public macro CodableKey(name: String) = #externalMacro(
   module: "KarrotCodableKitMacros",
-  type: "CodableKeyMacro"
+  type: "CodableKeyMacro",
 )

--- a/Sources/KarrotCodableKit/CustomCodable/Interface/CustomCodable.swift
+++ b/Sources/KarrotCodableKit/CustomCodable/Interface/CustomCodable.swift
@@ -7,52 +7,50 @@
 //
 //
 
-/**
- A macro that automatically generates `CodingKeys` and adopts the `Codable` protocol.
-
- This macro simplifies the process of making types Codable by generating all the necessary
- boilerplate code. For properties requiring custom key names, use the `@CodableKey` macro.
-
- - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-   When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
-   Default is `.default` which preserves the original property names.
-
- - Warning: This macro cannot be used with enum types.
-
- ## Example
- **AS-IS**
- ```swift
- @CustomCodable(codingKeyStyle: .snakeCase)
- struct Person {
-   let name: String
-   let userAge: Int
-
-   @CodableKey(name: "userProfileUrl")
-   let userProfileURL: String
- }
- ```
-
- **TO-BE**
- ```swift
- struct Person {
-   let name: String
-   let userAge: Int
-   let userProfileURL: String
-
-   private enum CodingKeys: String, CodingKey {
-     case name
-     case userAge = "user_age"
-     case userProfileURL = "userProfileUrl"
-   }
- }
-
- extension Person: Codable {
- }
- ```
- */
+/// A macro that automatically generates `CodingKeys` and adopts the `Codable` protocol.
+///
+/// This macro simplifies the process of making types Codable by generating all the necessary
+/// boilerplate code. For properties requiring custom key names, use the `@CodableKey` macro.
+///
+/// - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///  When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
+///  Default is `.default` which preserves the original property names.
+///
+/// - Warning: This macro cannot be used with enum types.
+///
+/// ## Example
+/// **AS-IS**
+/// ```swift
+/// @CustomCodable(codingKeyStyle: .snakeCase)
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///
+///  @CodableKey(name: "userProfileUrl")
+///  let userProfileURL: String
+/// }
+/// ```
+///
+/// **TO-BE**
+/// ```swift
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///  let userProfileURL: String
+///
+///  private enum CodingKeys: String, CodingKey {
+///    case name
+///    case userAge = "user_age"
+///    case userProfileURL = "userProfileUrl"
+///  }
+/// }
+///
+/// extension Person: Codable {
+/// }
+/// ```
 @attached(extension, conformances: Codable)
 @attached(member, names: named(CodingKeys))
 public macro CustomCodable(codingKeyStyle: CodingKeyStyle = .default) = #externalMacro(
   module: "KarrotCodableKitMacros",
-  type: "CustomCodableMacro"
+  type: "CustomCodableMacro",
 )

--- a/Sources/KarrotCodableKit/CustomCodable/Interface/CustomDecodable.swift
+++ b/Sources/KarrotCodableKit/CustomCodable/Interface/CustomDecodable.swift
@@ -7,53 +7,51 @@
 //
 //
 
-/**
- A macro that automatically generates `CodingKeys` and adopts the `Decodable` protocol.
-
- This macro eliminates the need to manually write coding keys and protocol conformance code
- when you only need to decode data. For properties requiring custom key names, use the
- `@CodableKey` macro.
-
- - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-   When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
-   Default is `.default` which preserves the original property names.
-
- - Warning: This macro cannot be used with enum types.
-
- ## Example
- **AS-IS**
- ```swift
- @CustomDecodable(codingKeyStyle: .snakeCase)
- struct Person {
-   let name: String
-   let userAge: Int
-
-   @CodableKey(name: "userProfileUrl")
-   let userProfileURL: String
- }
- ```
-
- **TO-BE**
- ```swift
- struct Person {
-   let name: String
-   let userAge: Int
-   let userProfileURL: String
-
-   private enum CodingKeys: String, CodingKey {
-     case name
-     case userAge = "user_age"
-     case userProfileURL = "userProfileUrl"
-   }
- }
-
- extension Person: Decodable {
- }
- ```
- */
+/// A macro that automatically generates `CodingKeys` and adopts the `Decodable` protocol.
+///
+/// This macro eliminates the need to manually write coding keys and protocol conformance code
+/// when you only need to decode data. For properties requiring custom key names, use the
+/// `@CodableKey` macro.
+///
+/// - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///  When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
+///  Default is `.default` which preserves the original property names.
+///
+/// - Warning: This macro cannot be used with enum types.
+///
+/// ## Example
+/// **AS-IS**
+/// ```swift
+/// @CustomDecodable(codingKeyStyle: .snakeCase)
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///
+///  @CodableKey(name: "userProfileUrl")
+///  let userProfileURL: String
+/// }
+/// ```
+///
+/// **TO-BE**
+/// ```swift
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///  let userProfileURL: String
+///
+///  private enum CodingKeys: String, CodingKey {
+///    case name
+///    case userAge = "user_age"
+///    case userProfileURL = "userProfileUrl"
+///  }
+/// }
+///
+/// extension Person: Decodable {
+/// }
+/// ```
 @attached(extension, conformances: Decodable)
 @attached(member, names: named(CodingKeys))
 public macro CustomDecodable(codingKeyStyle: CodingKeyStyle = .default) = #externalMacro(
   module: "KarrotCodableKitMacros",
-  type: "CustomDecodableMacro"
+  type: "CustomDecodableMacro",
 )

--- a/Sources/KarrotCodableKit/CustomCodable/Interface/CustomEncodable.swift
+++ b/Sources/KarrotCodableKit/CustomCodable/Interface/CustomEncodable.swift
@@ -7,53 +7,51 @@
 //
 //
 
-/**
- A macro that automatically generates `CodingKeys` and adopts the `Encodable` protocol.
-
- This macro eliminates the need to manually write coding keys and protocol conformance code
- when you only need to encode data. For properties requiring custom key names, use the
- `@CodableKey` macro.
-
- - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-   When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
-   Default is `.default` which preserves the original property names.
-
- - Warning: This macro cannot be used with enum types.
-
- ## Example
- **AS-IS**
- ```swift
- @CustomEncodable(codingKeyStyle: .snakeCase)
- struct Person {
-   let name: String
-   let userAge: Int
-
-   @CodableKey(name: "userProfileUrl")
-   let userProfileURL: String
- }
- ```
-
- **TO-BE**
- ```swift
- struct Person {
-   let name: String
-   let userAge: Int
-   let userProfileURL: String
-
-   private enum CodingKeys: String, CodingKey {
-     case name
-     case userAge = "user_age"
-     case userProfileURL = "userProfileUrl"
-   }
- }
-
- extension Person: Encodable {
- }
- ```
- */
+/// A macro that automatically generates `CodingKeys` and adopts the `Encodable` protocol.
+///
+/// This macro eliminates the need to manually write coding keys and protocol conformance code
+/// when you only need to encode data. For properties requiring custom key names, use the
+/// `@CodableKey` macro.
+///
+/// - Parameter codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///  When set to `.snakeCase`, property names will be converted to snake_case in the JSON.
+///  Default is `.default` which preserves the original property names.
+///
+/// - Warning: This macro cannot be used with enum types.
+///
+/// ## Example
+/// **AS-IS**
+/// ```swift
+/// @CustomEncodable(codingKeyStyle: .snakeCase)
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///
+///  @CodableKey(name: "userProfileUrl")
+///  let userProfileURL: String
+/// }
+/// ```
+///
+/// **TO-BE**
+/// ```swift
+/// struct Person {
+///  let name: String
+///  let userAge: Int
+///  let userProfileURL: String
+///
+///  private enum CodingKeys: String, CodingKey {
+///    case name
+///    case userAge = "user_age"
+///    case userProfileURL = "userProfileUrl"
+///  }
+/// }
+///
+/// extension Person: Encodable {
+/// }
+/// ```
 @attached(extension, conformances: Encodable)
 @attached(member, names: named(CodingKeys))
 public macro CustomEncodable(codingKeyStyle: CodingKeyStyle = .default) = #externalMacro(
   module: "KarrotCodableKitMacros",
-  type: "CustomEncodableMacro"
+  type: "CustomEncodableMacro",
 )

--- a/Sources/KarrotCodableKit/Encodable+ToDictionary.swift
+++ b/Sources/KarrotCodableKit/Encodable+ToDictionary.swift
@@ -9,20 +9,19 @@
 import Foundation
 
 extension Encodable {
-  /** Converts an `Encodable` to dictionary.
-
-    This method encodes the object using `JSONEncoder` and then converts the resulting data
-    to a dictionary using `JSONSerialization`.
-
-    - Returns: A dictionary with string keys and any values that represents the encoded object.
-    - Throws: An error if the encoding fails, or if the encoded data cannot be converted to a dictionary.
-   */
+  /// Converts an `Encodable` to dictionary.
+  ///
+  /// This method encodes the object using `JSONEncoder` and then converts the resulting data
+  /// to a dictionary using `JSONSerialization`.
+  ///
+  /// - Returns: A dictionary with string keys and any values that represents the encoded object.
+  /// - Throws: An error if the encoding fails, or if the encoded data cannot be converted to a dictionary.
   public func toDictionary() throws -> [String: Any] {
     let data = try JSONEncoder().encode(self)
     guard
       let dictionary = try JSONSerialization.jsonObject(
         with: data,
-        options: .fragmentsAllowed
+        options: .fragmentsAllowed,
       ) as? [String: Any]
     else {
       throw NSError(domain: "JSONSerialization Failed", code: 0)

--- a/Sources/KarrotCodableKit/PolymorphicCodable/DefaultEmptyPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/DefaultEmptyPolymorphicArrayValue.swift
@@ -45,7 +45,7 @@ public struct DefaultEmptyPolymorphicArrayValue<PolymorphicType: PolymorphicCoda
 
   public init(wrappedValue: [PolymorphicType.ExpectedType]) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: [PolymorphicType.ExpectedType], outcome: ResilientDecodingOutcome) {
@@ -72,17 +72,17 @@ extension DefaultEmptyPolymorphicArrayValue: Decodable {
         elements.append(value)
       }
 
-      self.wrappedValue = elements
-      self.outcome = .decodedSuccessfully
+      wrappedValue = elements
+      outcome = .decodedSuccessfully
     } catch {
       // Report error to error reporter
       #if DEBUG
       decoder.reportError(error)
-      self.wrappedValue = []
-      self.outcome = .recoveredFrom(error, wasReported: true)
+      wrappedValue = []
+      outcome = .recoveredFrom(error, wasReported: true)
       #else
-      self.wrappedValue = []
-      self.outcome = .recoveredFrom(error, wasReported: false)
+      wrappedValue = []
+      outcome = .recoveredFrom(error, wasReported: false)
       #endif
     }
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/Decoder+Polymorphic.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/Decoder+Polymorphic.swift
@@ -12,7 +12,7 @@ extension Decoder {
   public func decode<ExpectedType, PolymorphicMetaCodingKey: CodingKey>(
     codingKey: PolymorphicMetaCodingKey,
     matchingTypes: [PolymorphicDecodableType.Type],
-    fallbackType: PolymorphicDecodableType.Type?
+    fallbackType: PolymorphicDecodableType.Type?,
   ) throws -> ExpectedType {
     let container = try container(keyedBy: PolymorphicMetaCodingKey.self)
     let polymorphicTypeIdentifier = try container.decode(String.self, forKey: codingKey)
@@ -30,7 +30,7 @@ extension Decoder {
     guard let expectedValue = decodedValue as? ExpectedType else {
       throw PolymorphicCodableError.unableToCast(
         decoded: decodedValue,
-        into: String(describing: ExpectedType.self)
+        into: String(describing: ExpectedType.self),
       )
     }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/Encoder+Polymorphic.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/Encoder+Polymorphic.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Encoder {
   public func encode<ValueType, PolymorphicMetaCodingKey: CodingKey>(
     _ value: ValueType,
-    codingKey: PolymorphicMetaCodingKey
+    codingKey: PolymorphicMetaCodingKey,
   ) throws {
     guard let value = value as? PolymorphicEncodableType else {
       throw PolymorphicCodableError.unableToRepresentAsPolymorphicForEncoding("\(value)")
@@ -24,7 +24,7 @@ extension Encoder {
 
   public func encodeIfPresent<ValueType, PolymorphicMetaCodingKey: CodingKey>(
     _ value: ValueType?,
-    codingKey: PolymorphicMetaCodingKey
+    codingKey: PolymorphicMetaCodingKey,
   ) throws {
     guard let value else {
       var container = singleValueContainer()

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+DefaultEmptyPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+DefaultEmptyPolymorphicArrayValue.swift
@@ -11,7 +11,7 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: DefaultEmptyPolymorphicArrayValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> DefaultEmptyPolymorphicArrayValue<T> where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {
@@ -30,7 +30,7 @@ extension KeyedDecodingContainer {
 
   public func decodeIfPresent<T>(
     _ type: DefaultEmptyPolymorphicArrayValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> DefaultEmptyPolymorphicArrayValue<T>? where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+LossyOptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+LossyOptionalPolymorphicValue.swift
@@ -11,7 +11,7 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: LossyOptionalPolymorphicValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> LossyOptionalPolymorphicValue<T> where T: PolymorphicCodableStrategy {
     if let value = try decodeIfPresent(type, forKey: key) {
       value
@@ -22,7 +22,7 @@ extension KeyedDecodingContainer {
 
   public func decodeIfPresent<T>(
     _ type: LossyOptionalPolymorphicValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> LossyOptionalPolymorphicValue<T>? where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicArrayValue.swift
@@ -11,18 +11,18 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: OptionalPolymorphicArrayValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> OptionalPolymorphicArrayValue<T> where T: PolymorphicCodableStrategy {
     if let value = try decodeIfPresent(type, forKey: key) {
-      return value
+      value
     } else {
-      return OptionalPolymorphicArrayValue(wrappedValue: nil, outcome: .keyNotFound)
+      OptionalPolymorphicArrayValue(wrappedValue: nil, outcome: .keyNotFound)
     }
   }
 
   public func decodeIfPresent<T>(
     _ type: OptionalPolymorphicArrayValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> OptionalPolymorphicArrayValue<T>? where T: PolymorphicCodableStrategy {
     // Check if the key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicLossyArrayValue.swift
@@ -11,18 +11,18 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: OptionalPolymorphicLossyArrayValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> OptionalPolymorphicLossyArrayValue<T> where T: PolymorphicCodableStrategy {
     if let value = try decodeIfPresent(type, forKey: key) {
-      return value
+      value
     } else {
-      return OptionalPolymorphicLossyArrayValue(wrappedValue: nil, outcome: .keyNotFound)
+      OptionalPolymorphicLossyArrayValue(wrappedValue: nil, outcome: .keyNotFound)
     }
   }
 
   public func decodeIfPresent<T>(
     _ type: OptionalPolymorphicLossyArrayValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> OptionalPolymorphicLossyArrayValue<T>? where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+OptionalPolymorphicValue.swift
@@ -11,7 +11,7 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _ type: OptionalPolymorphicValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> OptionalPolymorphicValue<T> where T: PolymorphicCodableStrategy {
     if let value = try decodeIfPresent(type, forKey: key) {
       value
@@ -22,7 +22,7 @@ extension KeyedDecodingContainer {
 
   public func decodeIfPresent<T>(
     _ type: OptionalPolymorphicValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> OptionalPolymorphicValue<T>? where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+PolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedDecodingContainer+PolymorphicLossyArrayValue.swift
@@ -11,14 +11,14 @@ import Foundation
 extension KeyedDecodingContainer {
   public func decode<T>(
     _: PolymorphicLossyArrayValue<T>.Type,
-    forKey key: Key
+    forKey key: Key,
   ) throws -> PolymorphicLossyArrayValue<T> where T: PolymorphicCodableStrategy {
     // Return empty array if key is missing
     guard contains(key) else {
       #if DEBUG
       let context = DecodingError.Context(
         codingPath: codingPath + [key],
-        debugDescription: "Key not found but property is non-optional"
+        debugDescription: "Key not found but property is non-optional",
       )
       let error = DecodingError.keyNotFound(key, context)
       let decoder = try superDecoder(forKey: key)
@@ -26,7 +26,7 @@ extension KeyedDecodingContainer {
       return PolymorphicLossyArrayValue(
         wrappedValue: [],
         outcome: .recoveredFrom(error, wasReported: true),
-        results: []
+        results: [],
       )
       #else
       return PolymorphicLossyArrayValue(wrappedValue: [], outcome: .keyNotFound)
@@ -39,7 +39,7 @@ extension KeyedDecodingContainer {
 
   public func decodeIfPresent<T>(
     _: PolymorphicLossyArrayValue<T>.Type,
-    forKey key: Self.Key
+    forKey key: Self.Key,
   ) throws -> PolymorphicLossyArrayValue<T>? where T: PolymorphicCodableStrategy {
     // Check if key exists
     guard contains(key) else {

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+LossyOptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+LossyOptionalPolymorphicValue.swift
@@ -14,10 +14,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
-  public mutating func encode<T>(
-    _ value: LossyOptionalPolymorphicValue<T>,
-    forKey key: Key
-  ) throws where T: PolymorphicCodableStrategy {
+  public mutating func encode(
+    _ value: LossyOptionalPolymorphicValue<some PolymorphicCodableStrategy>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicArrayValue.swift
@@ -14,10 +14,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
-  public mutating func encode<T>(
-    _ value: OptionalPolymorphicArrayValue<T>,
-    forKey key: Key
-  ) throws where T: PolymorphicCodableStrategy {
+  public mutating func encode(
+    _ value: OptionalPolymorphicArrayValue<some PolymorphicCodableStrategy>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicLossyArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicLossyArrayValue.swift
@@ -14,10 +14,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
-  public mutating func encode<T>(
-    _ value: OptionalPolymorphicLossyArrayValue<T>,
-    forKey key: Key
-  ) throws where T: PolymorphicCodableStrategy {
+  public mutating func encode(
+    _ value: OptionalPolymorphicLossyArrayValue<some PolymorphicCodableStrategy>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Extensions/KeyedEncodingContainer+OptionalPolymorphicValue.swift
@@ -14,10 +14,10 @@ extension KeyedEncodingContainer {
   /// This mirrors Apple's default `Codable` behavior for optional properties, where a `nil` value
   /// results in the key being skipped rather than encoded as an explicit `null`. It is the encoding-side
   /// counterpart to the `decode(_:forKey:)` overload that treats a missing key as `nil`.
-  public mutating func encode<T>(
-    _ value: OptionalPolymorphicValue<T>,
-    forKey key: Key
-  ) throws where T: PolymorphicCodableStrategy {
+  public mutating func encode(
+    _ value: OptionalPolymorphicValue<some PolymorphicCodableStrategy>,
+    forKey key: Key,
+  ) throws {
     guard value.wrappedValue != nil else { return }
     try value.encode(to: superEncoder(forKey: key))
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodable.swift
@@ -8,21 +8,19 @@
 
 import Foundation
 
-/**
- A macro that enables polymorphic coding support for types.
-
- This macro automatically implements the necessary components for polymorphic
- encoding and decoding by adding PolymorphicCodableType conformance and generating
- appropriate CodingKeys.
-
- - Parameters:
-   - identifier: The string value used to identify this specific type in polymorphic coding.
-   - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-     Default is `.default` which preserves the original property names.
- */
+/// A macro that enables polymorphic coding support for types.
+///
+/// This macro automatically implements the necessary components for polymorphic
+/// encoding and decoding by adding PolymorphicCodableType conformance and generating
+/// appropriate CodingKeys.
+///
+/// - Parameters:
+///  - identifier: The string value used to identify this specific type in polymorphic coding.
+///  - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///    Default is `.default` which preserves the original property names.
 @attached(extension, conformances: PolymorphicCodableType, names: named(polymorphicIdentifier))
 @attached(member, names: named(CodingKeys))
 public macro PolymorphicCodable(
   identifier: String,
-  codingKeyStyle: CodingKeyStyle = .default
+  codingKeyStyle: CodingKeyStyle = .default,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicCodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicCodableStrategyProviding.swift
@@ -8,29 +8,27 @@
 
 import Foundation
 
-/**
- A macro for creating a polymorphic codable strategy.
-
- This macro generates a type-safe decoding strategy for polymorphic types based on an identifier
- field. It creates a strategy that can be used with different polymorphic decodable types
- to handle type-based deserialization. This functionality provides Swift implementation for the
- OpenAPI Specification's `oneOf` pattern, enabling type-safe polymorphic decoding.
-
- - Parameters:
-   - identifierCodingKey: The key name in the JSON used to determine the concrete type.
-      This corresponds to the `discriminator.propertyName` in OpenAPI Specification's oneOf definition.
-      The default value for this property is `"type"`.
-   - matchingTypes: An array of polymorphic types that this strategy will handle.
-   - fallbackType: Optional type to use when no matching type is found. If nil, decoding will fail
-                   when no matching type is found. The default value for this property is `nil`.
- */
+/// A macro for creating a polymorphic codable strategy.
+///
+/// This macro generates a type-safe decoding strategy for polymorphic types based on an identifier
+/// field. It creates a strategy that can be used with different polymorphic decodable types
+/// to handle type-based deserialization. This functionality provides Swift implementation for the
+/// OpenAPI Specification's `oneOf` pattern, enabling type-safe polymorphic decoding.
+///
+/// - Parameters:
+///  - identifierCodingKey: The key name in the JSON used to determine the concrete type.
+///     This corresponds to the `discriminator.propertyName` in OpenAPI Specification's oneOf definition.
+///     The default value for this property is `"type"`.
+///  - matchingTypes: An array of polymorphic types that this strategy will handle.
+///  - fallbackType: Optional type to use when no matching type is found. If nil, decoding will fail
+///                  when no matching type is found. The default value for this property is `nil`.
 @attached(peer, names: suffixed(CodableStrategy))
 @attached(member, names: arbitrary)
 public macro PolymorphicCodableStrategyProviding(
   identifierCodingKey: String = "type",
   matchingTypes: [PolymorphicDecodableType.Type],
-  fallbackType: PolymorphicDecodableType.Type? = nil
+  fallbackType: PolymorphicDecodableType.Type? = nil,
 ) = #externalMacro(
   module: "KarrotCodableKitMacros",
-  type: "PolymorphicCodableStrategyProvidingMacro"
+  type: "PolymorphicCodableStrategyProvidingMacro",
 )

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicDecodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicDecodable.swift
@@ -8,21 +8,19 @@
 
 import Foundation
 
-/**
- A macro that enables polymorphic decoding support for types.
-
- This macro automatically implements the necessary components for polymorphic
- decoding by adding PolymorphicDecodableType conformance and generating
- appropriate CodingKeys.
-
- - Parameters:
-   - identifier: The string value used to identify this specific type in polymorphic decoding.
-   - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-     Default is `.default` which preserves the original property names.
- */
+/// A macro that enables polymorphic decoding support for types.
+///
+/// This macro automatically implements the necessary components for polymorphic
+/// decoding by adding PolymorphicDecodableType conformance and generating
+/// appropriate CodingKeys.
+///
+/// - Parameters:
+///  - identifier: The string value used to identify this specific type in polymorphic decoding.
+///  - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///    Default is `.default` which preserves the original property names.
 @attached(extension, conformances: PolymorphicDecodableType, names: named(polymorphicIdentifier))
 @attached(member, names: named(CodingKeys))
 public macro PolymorphicDecodable(
   identifier: String,
-  codingKeyStyle: CodingKeyStyle = .default
+  codingKeyStyle: CodingKeyStyle = .default,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicDecodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEncodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/PolymorphicEncodable.swift
@@ -8,21 +8,19 @@
 
 import Foundation
 
-/**
- A macro that enables polymorphic encoding support for types.
-
- This macro automatically implements the necessary components for polymorphic
- encoding by adding PolymorphicEncodableType conformance and generating
- appropriate CodingKeys.
-
- - Parameters:
-   - identifier: The string value used to identify this specific type in polymorphic encoding.
-   - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
-     Default is `.default` which preserves the original property names.
- */
+/// A macro that enables polymorphic encoding support for types.
+///
+/// This macro automatically implements the necessary components for polymorphic
+/// encoding by adding PolymorphicEncodableType conformance and generating
+/// appropriate CodingKeys.
+///
+/// - Parameters:
+///  - identifier: The string value used to identify this specific type in polymorphic encoding.
+///  - codingKeyStyle: Specifies the naming convention to use when generating `CodingKeys`.
+///    Default is `.default` which preserves the original property names.
 @attached(extension, conformances: PolymorphicEncodableType, names: named(polymorphicIdentifier))
 @attached(member, names: named(CodingKeys))
 public macro PolymorphicEncodable(
   identifier: String,
-  codingKeyStyle: CodingKeyStyle = .default
+  codingKeyStyle: CodingKeyStyle = .default,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "PolymorphicEncodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/UnnestedPolymorphicCodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/UnnestedPolymorphicCodable.swift
@@ -75,5 +75,5 @@ import Foundation
 public macro UnnestedPolymorphicCodable(
   identifier: String,
   forKey nestedKey: String,
-  codingKeyStyle: CodingKeyStyle = .default
+  codingKeyStyle: CodingKeyStyle = .default,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "UnnestedPolymorphicCodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/Interface/UnnestedPolymorphicDecodable.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/Interface/UnnestedPolymorphicDecodable.swift
@@ -74,5 +74,5 @@ import Foundation
 public macro UnnestedPolymorphicDecodable(
   identifier: String,
   forKey nestedKey: String,
-  codingKeyStyle: CodingKeyStyle = .default
+  codingKeyStyle: CodingKeyStyle = .default,
 ) = #externalMacro(module: "KarrotCodableKitMacros", type: "UnnestedPolymorphicDecodableMacro")

--- a/Sources/KarrotCodableKit/PolymorphicCodable/LossyOptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/LossyOptionalPolymorphicValue.swift
@@ -34,7 +34,7 @@ public struct LossyOptionalPolymorphicValue<PolymorphicType: PolymorphicCodableS
 
   public init(wrappedValue: PolymorphicType.ExpectedType?) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: PolymorphicType.ExpectedType?, outcome: ResilientDecodingOutcome) {
@@ -54,7 +54,7 @@ extension LossyOptionalPolymorphicValue: Encodable {
   public func encode(to encoder: Encoder) throws {
     try encoder.encodeIfPresent(
       wrappedValue,
-      codingKey: PolymorphicType.polymorphicMetaCodingKey
+      codingKey: PolymorphicType.polymorphicMetaCodingKey,
     )
   }
 }
@@ -62,25 +62,25 @@ extension LossyOptionalPolymorphicValue: Encodable {
 extension LossyOptionalPolymorphicValue: Decodable {
   public init(from decoder: Decoder) throws {
     do {
-      self.wrappedValue = try PolymorphicType.decode(from: decoder)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try PolymorphicType.decode(from: decoder)
+      outcome = .decodedSuccessfully
 
     } catch DecodingError.keyNotFound {
-      self.wrappedValue = nil
-      self.outcome = .keyNotFound
+      wrappedValue = nil
+      outcome = .keyNotFound
 
     } catch DecodingError.valueNotFound(let rawType, _) where rawType == PolymorphicType.ExpectedType.self {
-      self.wrappedValue = nil
-      self.outcome = .valueWasNil
+      wrappedValue = nil
+      outcome = .valueWasNil
 
     } catch {
       #if DEBUG
       // Report error to resilient decoding error reporter
       decoder.reportError(error)
-      self.wrappedValue = nil
-      self.outcome = .recoveredFrom(error, wasReported: true)
+      wrappedValue = nil
+      outcome = .recoveredFrom(error, wasReported: true)
       #else
-      self.outcome = .recoveredFrom(error, wasReported: false)
+      outcome = .recoveredFrom(error, wasReported: false)
       #endif
     }
   }

--- a/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicArrayValue.swift
@@ -44,7 +44,7 @@ public struct OptionalPolymorphicArrayValue<PolymorphicType: PolymorphicCodableS
   /// Initializes the property wrapper with an optional array of values.
   public init(wrappedValue: [PolymorphicType.ExpectedType]?) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   /// Initializes the property wrapper with an optional array of values and a decoding outcome.

--- a/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/OptionalPolymorphicValue.swift
@@ -32,7 +32,7 @@ public struct OptionalPolymorphicValue<PolymorphicType: PolymorphicCodableStrate
 
   public init(wrappedValue: PolymorphicType.ExpectedType?) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: PolymorphicType.ExpectedType?, outcome: ResilientDecodingOutcome) {
@@ -52,7 +52,7 @@ extension OptionalPolymorphicValue: Encodable {
   public func encode(to encoder: Encoder) throws {
     try encoder.encodeIfPresent(
       wrappedValue,
-      codingKey: PolymorphicType.polymorphicMetaCodingKey
+      codingKey: PolymorphicType.polymorphicMetaCodingKey,
     )
   }
 }
@@ -60,16 +60,16 @@ extension OptionalPolymorphicValue: Encodable {
 extension OptionalPolymorphicValue: Decodable {
   public init(from decoder: Decoder) throws {
     do {
-      self.wrappedValue = try PolymorphicType.decode(from: decoder)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try PolymorphicType.decode(from: decoder)
+      outcome = .decodedSuccessfully
 
     } catch DecodingError.keyNotFound {
-      self.wrappedValue = nil
-      self.outcome = .keyNotFound
+      wrappedValue = nil
+      outcome = .keyNotFound
 
     } catch DecodingError.valueNotFound(let rawType, _) where rawType == PolymorphicType.ExpectedType.self {
-      self.wrappedValue = nil
-      self.outcome = .valueWasNil
+      wrappedValue = nil
+      outcome = .valueWasNil
 
     } catch {
       // OptionalPolymorphicValue throws errors instead of recovering

--- a/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicArrayValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicArrayValue.swift
@@ -26,7 +26,7 @@ public struct PolymorphicArrayValue<PolymorphicType: PolymorphicCodableStrategy>
   /// Initializes the property wrapper with a pre-decoded array of values.
   public init(wrappedValue: [PolymorphicType.ExpectedType]) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: [PolymorphicType.ExpectedType], outcome: ResilientDecodingOutcome) {
@@ -52,8 +52,8 @@ extension PolymorphicArrayValue: Decodable {
       elements.append(value)
     }
 
-    self.wrappedValue = elements
-    self.outcome = .decodedSuccessfully
+    wrappedValue = elements
+    outcome = .decodedSuccessfully
   }
 }
 

--- a/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicValue.swift
+++ b/Sources/KarrotCodableKit/PolymorphicCodable/PolymorphicValue.swift
@@ -29,7 +29,7 @@ public struct PolymorphicValue<PolymorphicType: PolymorphicCodableStrategy> {
   /// Initializes the property wrapper with a pre-decoded value.
   public init(wrappedValue: PolymorphicType.ExpectedType) {
     self.wrappedValue = wrappedValue
-    self.outcome = .decodedSuccessfully
+    outcome = .decodedSuccessfully
   }
 
   init(wrappedValue: PolymorphicType.ExpectedType, outcome: ResilientDecodingOutcome) {
@@ -53,8 +53,8 @@ extension PolymorphicValue: Encodable {
 extension PolymorphicValue: Decodable {
   public init(from decoder: Decoder) throws {
     do {
-      self.wrappedValue = try PolymorphicType.decode(from: decoder)
-      self.outcome = .decodedSuccessfully
+      wrappedValue = try PolymorphicType.decode(from: decoder)
+      outcome = .decodedSuccessfully
     } catch {
       #if DEBUG
       decoder.reportError(error)

--- a/Sources/KarrotCodableKit/Resilient/ErrorReporting.swift
+++ b/Sources/KarrotCodableKit/Resilient/ErrorReporting.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - Enabling Error Reporting
 
 extension CodingUserInfoKey {
-  public static let resilientDecodingErrorReporter = CodingUserInfoKey(
+  public static let resilientDecodingErrorReporter: CodingUserInfoKey = .init(
     rawValue: "ResilientDecodingErrorReporter"
   )!
 }
@@ -56,7 +56,7 @@ extension JSONDecoder {
   public func decode<T: Decodable>(
     _ type: T.Type,
     from data: Data,
-    reportResilientDecodingErrors: Bool
+    reportResilientDecodingErrors: Bool,
   ) throws -> (T, ErrorDigest?) {
     guard reportResilientDecodingErrors else {
       return (try decode(T.self, from: data), nil)
@@ -96,7 +96,7 @@ public final class ResilientDecodingErrorReporter {
     currentDigest.root.insert(error, at: path)
   }
 
-  fileprivate var currentDigest = ErrorDigest()
+  fileprivate var currentDigest: ErrorDigest = .init()
   private var hasErrors = false
 }
 
@@ -107,11 +107,12 @@ public struct ErrorDigest {
   }
 
   public func errors(includeUnknownNovelValueErrors: Bool) -> [Error] {
-    let allErrors: [Error] = if mayBeMissingReportedErrors {
-      [MayBeMissingReportedErrors()] + root.errors
-    } else {
-      root.errors
-    }
+    let allErrors: [Error] =
+      if mayBeMissingReportedErrors {
+        [MayBeMissingReportedErrors()] + root.errors
+      } else {
+        root.errors
+      }
 
     return allErrors.filter { includeUnknownNovelValueErrors || !($0 is UnknownNovelValueError) }
   }
@@ -140,7 +141,7 @@ public struct ErrorDigest {
     }
   }
 
-  fileprivate var root = Node()
+  fileprivate var root: Node = .init()
 }
 
 // MARK: - Reporting Errors

--- a/Sources/KarrotCodableKit/Resilient/ResilientDecodingOutcome.swift
+++ b/Sources/KarrotCodableKit/Resilient/ResilientDecodingOutcome.swift
@@ -39,10 +39,10 @@ extension ResilientDecodingOutcome: Equatable {
 /// so we define an empty struct with `static` properties and functions which match the `enum` above.
 /// This reduces the number of places we need to use `#if DEBUG` substantially.
 public struct ResilientDecodingOutcome: Sendable {
-  public static let decodedSuccessfully = Self()
-  public static let keyNotFound = Self()
-  public static let valueWasNil = Self()
-  public static let recoveredFromDebugOnlyError = Self()
+  public static let decodedSuccessfully: Self = .init()
+  public static let keyNotFound: Self = .init()
+  public static let valueWasNil: Self = .init()
+  public static let recoveredFromDebugOnlyError: Self = .init()
   public static func recoveredFrom(_: any Error, wasReported: Bool) -> Self { Self() }
 }
 #endif

--- a/Sources/KarrotCodableKitMacros/CustomCodableMacros/CodableKeyMacro.swift
+++ b/Sources/KarrotCodableKitMacros/CustomCodableMacros/CodableKeyMacro.swift
@@ -19,7 +19,7 @@ public struct CodableKeyMacro: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     // Does nothing, used only to decorate members with data
     []

--- a/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomCodableMacro.swift
@@ -14,7 +14,7 @@ public enum CustomCodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension CustomCodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     if declaration.is(EnumDeclSyntax.self) {
       throw CodableKitError.cannotApplyToEnum

--- a/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomDecodableMacro.swift
@@ -14,7 +14,7 @@ public enum CustomDecodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension CustomDecodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     if declaration.is(EnumDeclSyntax.self) {
       throw CodableKitError.cannotApplyToEnum

--- a/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomEncodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/CustomCodableMacros/CustomEncodableMacro.swift
@@ -14,7 +14,7 @@ public enum CustomEncodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension CustomEncodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     if declaration.is(EnumDeclSyntax.self) {
       throw CodableKitError.cannotApplyToEnum

--- a/Sources/KarrotCodableKitMacros/Extensions/String+SnakeCase.swift
+++ b/Sources/KarrotCodableKitMacros/Extensions/String+SnakeCase.swift
@@ -79,10 +79,8 @@ extension String {
     }
     words.append(wordStart..<searchRange.upperBound)
 
-    let result = words.map { range in
+    return words.map { range in
       self[range].lowercased()
     }.joined(separator: "_")
-
-    return result
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableMacro.swift
@@ -14,7 +14,7 @@ public enum PolymorphicCodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension PolymorphicCodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     let arguments = try PolymorphicMacroArgumentValidator.extractPolymorphicArguments(from: node)
     let accessLevel = AccessLevelModifier.stringValue(from: declaration)
@@ -36,8 +36,8 @@ extension PolymorphicCodableMacro: ExtensionMacro {
         for: type,
         identifier: arguments.identifier,
         protocolType: .codable,
-        accessLevel: accessLevel
-      ),
+        accessLevel: accessLevel,
+      )
     ]
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableStrategyMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicCodableStrategyMacro.swift
@@ -18,7 +18,7 @@ extension PolymorphicCodableStrategyProvidingMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
       throw CodableKitError.message("Macro must be attached to a protocol.")
@@ -34,8 +34,12 @@ extension PolymorphicCodableStrategyProvidingMacro: MemberMacro {
       DeclSyntax("typealias PolymorphicArray = PolymorphicArrayValue<\(raw: strategyStructName)>"),
       DeclSyntax("typealias OptionalPolymorphicArray = OptionalPolymorphicArrayValue<\(raw: strategyStructName)>"),
       DeclSyntax("typealias PolymorphicLossyArray = PolymorphicLossyArrayValue<\(raw: strategyStructName)>"),
-      DeclSyntax("typealias OptionalPolymorphicLossyArray = OptionalPolymorphicLossyArrayValue<\(raw: strategyStructName)>"),
-      DeclSyntax("typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<\(raw: strategyStructName)>"),
+      DeclSyntax(
+        "typealias OptionalPolymorphicLossyArray = OptionalPolymorphicLossyArrayValue<\(raw: strategyStructName)>"
+      ),
+      DeclSyntax(
+        "typealias DefaultEmptyPolymorphicArray = DefaultEmptyPolymorphicArrayValue<\(raw: strategyStructName)>"
+      ),
     ]
   }
 }
@@ -46,7 +50,7 @@ extension PolymorphicCodableStrategyProvidingMacro: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else { return [] }
 
@@ -59,7 +63,7 @@ extension PolymorphicCodableStrategyProvidingMacro: PeerMacro {
 
     let identifierCodingKeyString = SyntaxHelper.findArgument(
       named: "identifierCodingKey",
-      in: arguments
+      in: arguments,
     ).flatMap {
       SyntaxHelper.extractString(from: $0)
     } ?? "type"
@@ -101,7 +105,7 @@ extension PolymorphicCodableStrategyProvidingMacro: PeerMacro {
           }
         }
         """
-      ),
+      )
     ]
   }
 

--- a/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicDecodableMacro.swift
@@ -14,7 +14,7 @@ public enum PolymorphicDecodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension PolymorphicDecodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     let arguments = try PolymorphicMacroArgumentValidator.extractPolymorphicArguments(from: node)
     let accessLevel = AccessLevelModifier.stringValue(from: declaration)
@@ -36,8 +36,8 @@ extension PolymorphicDecodableMacro: ExtensionMacro {
         for: type,
         identifier: arguments.identifier,
         protocolType: .decodable,
-        accessLevel: accessLevel
-      ),
+        accessLevel: accessLevel,
+      )
     ]
   }
 }

--- a/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicEncodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/PolymorphicCodableMacros/PolymorphicEncodableMacro.swift
@@ -14,7 +14,7 @@ public enum PolymorphicEncodableMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     [try CodingKeysSyntaxFactory.makeCodingKeysSyntax(from: declaration)]
   }
@@ -26,7 +26,7 @@ extension PolymorphicEncodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     let arguments = try PolymorphicMacroArgumentValidator.extractPolymorphicArguments(from: node)
     let accessLevel = AccessLevelModifier.stringValue(from: declaration)
@@ -36,8 +36,8 @@ extension PolymorphicEncodableMacro: ExtensionMacro {
         for: type,
         identifier: arguments.identifier,
         protocolType: .encodable,
-        accessLevel: accessLevel
-      ),
+        accessLevel: accessLevel,
+      )
     ]
   }
 }

--- a/Sources/KarrotCodableKitMacros/Supports/AccessLevelModifier.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/AccessLevelModifier.swift
@@ -36,8 +36,9 @@ enum AccessLevelModifier: String, Comparable, CaseIterable, Sendable {
   }
 
   static func < (lhs: AccessLevelModifier, rhs: AccessLevelModifier) -> Bool {
-    guard let lhs = Self.allCases.firstIndex(of: lhs),
-          let rhs = Self.allCases.firstIndex(of: rhs)
+    guard
+      let lhs = Self.allCases.firstIndex(of: lhs),
+      let rhs = Self.allCases.firstIndex(of: rhs)
     else {
       return false
     }
@@ -45,17 +46,18 @@ enum AccessLevelModifier: String, Comparable, CaseIterable, Sendable {
   }
 
   static func stringValue(from declaration: some DeclGroupSyntax) -> String {
-    let accessLevel = if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
-      protocolDecl.accessLevel
-    } else if let classDecl = declaration.as(ClassDeclSyntax.self) {
-      classDecl.accessLevel
-    } else if let structDecl = declaration.as(StructDeclSyntax.self) {
-      structDecl.accessLevel
-    } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
-      enumDecl.accessLevel
-    } else {
-      AccessLevelModifier.internal
-    }
+    let accessLevel =
+      if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+        protocolDecl.accessLevel
+      } else if let classDecl = declaration.as(ClassDeclSyntax.self) {
+        classDecl.accessLevel
+      } else if let structDecl = declaration.as(StructDeclSyntax.self) {
+        structDecl.accessLevel
+      } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+        enumDecl.accessLevel
+      } else {
+        AccessLevelModifier.internal
+      }
 
     guard accessLevel != .internal else { return "" }
 

--- a/Sources/KarrotCodableKitMacros/Supports/Diagnostics.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Diagnostics.swift
@@ -30,11 +30,11 @@ enum CodableKitError: Error, CustomStringConvertible {
 
 struct ConstantWithInitializerWarning: DiagnosticMessage {
   let message = "Immutable property will not be decoded because it is declared with an initial value which cannot be overwritten"
-  let diagnosticID = MessageID(domain: "KarrotCodableKitMacros", id: "constantWithInitializer")
-  let severity = DiagnosticSeverity.warning
+  let diagnosticID: MessageID = .init(domain: "KarrotCodableKitMacros", id: "constantWithInitializer")
+  let severity: DiagnosticSeverity = .warning
 }
 
 struct MakePropertyMutableFixIt: FixItMessage {
   let message = "Make the property mutable instead"
-  let fixItID = MessageID(domain: "KarrotCodableKitMacros", id: "makePropertyMutable")
+  let fixItID: MessageID = .init(domain: "KarrotCodableKitMacros", id: "makePropertyMutable")
 }

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/CodingKeysSyntaxFactory.swift
@@ -84,7 +84,7 @@ enum CodingKeysSyntaxFactory {
 
         return PropertyDeclaration(
           variableDecl: variableDecl,
-          propertyName: propertyName
+          propertyName: propertyName,
         )
       }
   }

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicEnumCodableFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicEnumCodableFactory.swift
@@ -29,7 +29,7 @@ enum PolymorphicEnumCodableFactory {
     with caseInfos: [CaseInfo],
     identifierCodingKey: String,
     accessLevel: String,
-    fallbackCaseName: String?
+    fallbackCaseName: String?,
   ) -> String {
     let caseSwitches = caseInfos.map { caseInfo in
       """
@@ -44,7 +44,8 @@ enum PolymorphicEnumCodableFactory {
         guard let fallbackCase else { return "" } // This will be caught by validateFallbackCaseName
         return """
           default:
-              self = .\(fallbackCaseName)(\(fallbackCase.parameterName)try \(fallbackCase.associatedType)(from: decoder))
+              self = .\(fallbackCaseName)(\(fallbackCase.parameterName)try \(fallbackCase
+          .associatedType)(from: decoder))
           """
       } else {
         return """
@@ -69,7 +70,7 @@ enum PolymorphicEnumCodableFactory {
 
   static func makeEncodeToEncoder(
     with caseInfos: [CaseInfo],
-    accessLevel: String
+    accessLevel: String,
   ) -> String {
     let encodeSwitches = caseInfos.map { caseInfo in
       """
@@ -108,7 +109,7 @@ enum PolymorphicEnumCodableFactory {
   /// Validates and extracts the fallbackCaseName from the attribute arguments
   static func validateFallbackCaseName(
     in node: AttributeSyntax,
-    caseInfos: [CaseInfo]
+    caseInfos: [CaseInfo],
   ) throws -> String? {
     let fallbackCaseNameString = node.arguments?.as(LabeledExprListSyntax.self)
       .flatMap {
@@ -161,7 +162,7 @@ enum PolymorphicEnumCodableFactory {
         return CaseInfo(
           name: caseName,
           parameterName: parameterName,
-          associatedType: associatedValue.type
+          associatedType: associatedValue.type,
         )
       }
   }

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicExtensionFactory.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/PolymorphicExtensionFactory.swift
@@ -29,7 +29,7 @@ public enum PolymorphicExtensionFactory {
     for type: some TypeSyntaxProtocol,
     identifier: String,
     protocolType: PolymorphicProtocolType,
-    accessLevel: String
+    accessLevel: String,
   ) throws -> ExtensionDeclSyntax {
     try ExtensionDeclSyntax(
       """
@@ -46,7 +46,7 @@ public enum PolymorphicExtensionFactory {
     protocolType: PolymorphicProtocolType,
     accessLevel: String,
     initFromDecoder: String? = nil,
-    encodeToEncoder: String? = nil
+    encodeToEncoder: String? = nil,
   ) throws -> ExtensionDeclSyntax {
     var extensionBody = "\(accessLevel)static var polymorphicIdentifier: String { \"\(identifier)\" }"
 

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicCodeGenerator.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicCodeGenerator.swift
@@ -37,7 +37,7 @@ public enum UnnestedPolymorphicCodeGenerator {
     from declaration: some DeclGroupSyntax,
     structName: String,
     codingKeyStyle: String?,
-    macroType: MacroType = .codable
+    macroType: MacroType = .codable,
   ) throws -> DeclSyntax {
     guard !declaration.is(EnumDeclSyntax.self) else {
       throw CodableKitError.cannotApplyToEnum

--- a/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicMethodGenerator.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/Factory/UnnestedPolymorphicMethodGenerator.swift
@@ -14,13 +14,13 @@ public enum UnnestedPolymorphicMethodGenerator {
     from declaration: some DeclGroupSyntax,
     nestedKey: String,
     accessLevel: String,
-    structName: String
+    structName: String,
   ) -> String {
     let assignableProperties = extractAssignableProperties(from: declaration)
     let functionBody = createInitFunctionBody(
       assignableProperties: assignableProperties,
       nestedKey: nestedKey,
-      structName: structName
+      structName: structName,
     )
 
     return """
@@ -34,13 +34,13 @@ public enum UnnestedPolymorphicMethodGenerator {
     from declaration: some DeclGroupSyntax,
     nestedKey: String,
     accessLevel: String,
-    structName: String
+    structName: String,
   ) -> String {
     let propertyParameters = extractPropertyParameters(from: declaration)
     let functionBody = createEncodeFunctionBody(
       propertyParameters: propertyParameters,
       nestedKey: nestedKey,
-      structName: structName
+      structName: structName,
     )
 
     return """
@@ -81,7 +81,7 @@ public enum UnnestedPolymorphicMethodGenerator {
   private static func createInitFunctionBody(
     assignableProperties: [String],
     nestedKey: String,
-    structName: String
+    structName: String,
   ) -> String {
     if assignableProperties.isEmpty {
       """
@@ -122,7 +122,7 @@ public enum UnnestedPolymorphicMethodGenerator {
   private static func createEncodeFunctionBody(
     propertyParameters: [String],
     nestedKey: String,
-    structName: String
+    structName: String,
   ) -> String {
     if propertyParameters.isEmpty {
       """

--- a/Sources/KarrotCodableKitMacros/Supports/PolymorphicMacroArgumentValidator.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/PolymorphicMacroArgumentValidator.swift
@@ -90,7 +90,7 @@ public enum PolymorphicMacroArgumentValidator {
     return UnnestedPolymorphicMacroArguments(
       identifier: identifier,
       nestedKey: nestedKey,
-      codingKeyStyle: codingKeyStyle
+      codingKeyStyle: codingKeyStyle,
     )
   }
 

--- a/Sources/KarrotCodableKitMacros/Supports/PropertyAnalyzer.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/PropertyAnalyzer.swift
@@ -41,7 +41,7 @@ enum PropertyAnalyzer {
           name: propertyDeclaration.propertyName,
           type: typeString,
           isOptional: isOptional,
-          isConstant: isConstant
+          isConstant: isConstant,
         )
       }
   }
@@ -73,7 +73,7 @@ enum PropertyAnalyzer {
 
           return ConstantPropertyInfo(
             name: propertyName,
-            value: initializerValue
+            value: initializerValue,
           )
         }
 

--- a/Sources/KarrotCodableKitMacros/Supports/PropertyDiagnosticHelper.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/PropertyDiagnosticHelper.swift
@@ -16,7 +16,7 @@ enum PropertyDiagnosticHelper {
   /// Suggests changing 'let' to 'var' for properties that cannot be decoded properly.
   static func generateConstantWithInitializerDiagnostics(
     for declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) {
     let propertyDeclarations = CodingKeysSyntaxFactory.extractStoredPropertyDeclarations(from: declaration)
 
@@ -40,15 +40,15 @@ enum PropertyDiagnosticHelper {
           changes: [
             FixIt.Change.replace(
               oldNode: Syntax(letToken),
-              newNode: Syntax(TokenSyntax.keyword(.var, trailingTrivia: letToken.trailingTrivia))
-            ),
-          ]
+              newNode: Syntax(TokenSyntax.keyword(.var, trailingTrivia: letToken.trailingTrivia)),
+            )
+          ],
         )
 
         let diagnostic = Diagnostic(
           node: propDecl.variableDecl,
           message: ConstantWithInitializerWarning(),
-          fixIts: [fixIt]
+          fixIts: [fixIt],
         )
         context.diagnose(diagnostic)
       }

--- a/Sources/KarrotCodableKitMacros/Supports/SyntaxHelper.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/SyntaxHelper.swift
@@ -14,7 +14,7 @@ enum SyntaxHelper {
   /// Helper function to find argument by name in LabeledExprListSyntax
   static func findArgument(
     named name: String,
-    in arguments: LabeledExprListSyntax
+    in arguments: LabeledExprListSyntax,
   ) -> ExprSyntax? {
     arguments.first { $0.label?.text == name }?.expression
   }

--- a/Sources/KarrotCodableKitMacros/Supports/UnnestedPolymorphicValidation.swift
+++ b/Sources/KarrotCodableKitMacros/Supports/UnnestedPolymorphicValidation.swift
@@ -13,7 +13,7 @@ public enum UnnestedPolymorphicValidation {
 
   public static func validateDeclarationIsNotEnum(
     _ declaration: some DeclGroupSyntax,
-    macroName: String
+    macroName: String,
   ) throws {
     guard declaration.is(EnumDeclSyntax.self) else { return }
     let enumMacroName = macroName.replacingOccurrences(of: "UnnestedPolymorphic", with: "PolymorphicEnum")
@@ -36,7 +36,7 @@ public enum UnnestedPolymorphicValidation {
     declaration: some DeclGroupSyntax,
     identifier: String,
     nestedKey: String,
-    macroName: String
+    macroName: String,
   ) throws {
     try validateDeclarationIsNotEnum(declaration, macroName: macroName)
     try validateIdentifier(identifier)

--- a/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/BaseUnnestedPolymorphicMacro.swift
+++ b/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/BaseUnnestedPolymorphicMacro.swift
@@ -25,7 +25,7 @@ extension UnnestedPolymorphicMacroType {
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext,
-    for macroType: (some UnnestedPolymorphicMacroType).Type
+    for macroType: (some UnnestedPolymorphicMacroType).Type,
   ) throws -> [DeclSyntax] {
     try UnnestedPolymorphicValidation.validateDeclarationIsNotEnum(declaration, macroName: macroType.macroName)
 
@@ -34,7 +34,7 @@ extension UnnestedPolymorphicMacroType {
 
     PropertyDiagnosticHelper.generateConstantWithInitializerDiagnostics(
       for: declaration,
-      in: context
+      in: context,
     )
 
     let codingKeyStyleArgument = arguments.codingKeyStyle.map { ".\($0)" }
@@ -45,7 +45,7 @@ extension UnnestedPolymorphicMacroType {
         from: declaration,
         structName: nestedDataStructName,
         codingKeyStyle: codingKeyStyleArgument,
-        macroType: macroType.macroType
+        macroType: macroType.macroType,
       ),
     ]
   }
@@ -56,7 +56,7 @@ extension UnnestedPolymorphicMacroType {
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext,
-    for macroType: (some UnnestedPolymorphicMacroType).Type
+    for macroType: (some UnnestedPolymorphicMacroType).Type,
   ) throws -> [ExtensionDeclSyntax] {
     try UnnestedPolymorphicValidation.validateDeclarationIsNotEnum(declaration, macroName: macroType.macroName)
 
@@ -65,7 +65,7 @@ extension UnnestedPolymorphicMacroType {
       declaration: declaration,
       identifier: arguments.identifier,
       nestedKey: arguments.nestedKey,
-      macroName: macroType.macroName
+      macroName: macroType.macroName,
     )
 
     let accessLevel = AccessLevelModifier.stringValue(from: declaration)
@@ -74,19 +74,20 @@ extension UnnestedPolymorphicMacroType {
       from: declaration,
       nestedKey: arguments.nestedKey,
       accessLevel: accessLevel,
-      structName: nestedDataStructName
+      structName: nestedDataStructName,
     )
 
-    let encodeToEncoder: String? = if macroType.protocolType != .decodable {
-      UnnestedPolymorphicMethodGenerator.generateEncodeToEncoder(
-        from: declaration,
-        nestedKey: arguments.nestedKey,
-        accessLevel: accessLevel,
-        structName: nestedDataStructName
-      )
-    } else {
-      nil
-    }
+    let encodeToEncoder: String? =
+      if macroType.protocolType != .decodable {
+        UnnestedPolymorphicMethodGenerator.generateEncodeToEncoder(
+          from: declaration,
+          nestedKey: arguments.nestedKey,
+          accessLevel: accessLevel,
+          structName: nestedDataStructName,
+        )
+      } else {
+        nil
+      }
 
     return [
       try PolymorphicExtensionFactory.makeUnnestedPolymorphicExtension(
@@ -95,8 +96,8 @@ extension UnnestedPolymorphicMacroType {
         protocolType: macroType.protocolType,
         accessLevel: accessLevel,
         initFromDecoder: initFromDecoder,
-        encodeToEncoder: encodeToEncoder
-      ),
+        encodeToEncoder: encodeToEncoder,
+      )
     ]
   }
 }

--- a/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicCodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicCodableMacro.swift
@@ -19,13 +19,13 @@ public enum UnnestedPolymorphicCodableMacro: MemberMacro, UnnestedPolymorphicMac
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     try generateMemberDeclarations(
       of: node,
       providingMembersOf: declaration,
       in: context,
-      for: Self.self
+      for: Self.self,
     )
   }
 }
@@ -36,7 +36,7 @@ extension UnnestedPolymorphicCodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     try generateExtensionDeclarations(
       of: node,
@@ -44,7 +44,7 @@ extension UnnestedPolymorphicCodableMacro: ExtensionMacro {
       providingExtensionsOf: type,
       conformingTo: protocols,
       in: context,
-      for: Self.self
+      for: Self.self,
     )
   }
 }

--- a/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicDecodableMacro.swift
+++ b/Sources/KarrotCodableKitMacros/UnnestedPolymorphicCodableMacro/UnnestedPolymorphicDecodableMacro.swift
@@ -19,13 +19,13 @@ public enum UnnestedPolymorphicDecodableMacro: MemberMacro, UnnestedPolymorphicM
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [DeclSyntax] {
     try generateMemberDeclarations(
       of: node,
       providingMembersOf: declaration,
       in: context,
-      for: Self.self
+      for: Self.self,
     )
   }
 }
@@ -36,7 +36,7 @@ extension UnnestedPolymorphicDecodableMacro: ExtensionMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingExtensionsOf type: some TypeSyntaxProtocol,
     conformingTo protocols: [TypeSyntax],
-    in context: some MacroExpansionContext
+    in context: some MacroExpansionContext,
   ) throws -> [ExtensionDeclSyntax] {
     try generateExtensionDeclarations(
       of: node,
@@ -44,7 +44,7 @@ extension UnnestedPolymorphicDecodableMacro: ExtensionMacro {
       providingExtensionsOf: type,
       conformingTo: protocols,
       in: context,
-      for: Self.self
+      for: Self.self,
     )
   }
 }

--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyCodableTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 4/9/25.
 //
 
-import Testing
 import Foundation
+import Testing
 @testable import KarrotCodableKit
 
 struct AnyCodableTests {
@@ -19,7 +19,8 @@ struct AnyCodableTests {
     var hasUnderscore: String
   }
 
-  @Test func testJSONDecoding() throws {
+  @Test
+  func `JSON decoding`() throws {
     // given
     let json = """
       {
@@ -42,16 +43,17 @@ struct AnyCodableTests {
     let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
 
     // then
-    #expect(dictionary["boolean"]?.value as! Bool == true)
-    #expect(dictionary["integer"]?.value as! Int == 42)
-    #expect(abs(dictionary["double"]?.value as! Double - 3.141592653589793) < 0.001)
-    #expect(dictionary["string"]?.value as! String == "string")
-    #expect(dictionary["array"]?.value as! [Int] == [1, 2, 3])
-    #expect(dictionary["nested"]?.value as! [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
-    #expect(dictionary["null"]?.value as! NSNull == NSNull())
+    #expect(dictionary["boolean"]?.value as? Bool == true)
+    #expect(dictionary["integer"]?.value as? Int == 42)
+    #expect(abs(try #require(dictionary["double"]?.value as? Double) - 3.141592653589793) < 0.001)
+    #expect(dictionary["string"]?.value as? String == "string")
+    #expect(dictionary["array"]?.value as? [Int] == [1, 2, 3])
+    #expect(dictionary["nested"]?.value as? [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
+    #expect(dictionary["null"]?.value as? NSNull == NSNull())
   }
 
-  @Test func testJSONDecodingEquatable() throws {
+  @Test
+  func `JSON decoding equatable`() throws {
     // given
     let json = """
       {
@@ -84,13 +86,14 @@ struct AnyCodableTests {
     #expect(dictionary1["null"] == dictionary2["null"])
   }
 
-  @Test func testJSONEncoding() throws {
+  @Test
+  func `JSON encoding`() throws {
     // given
     let someCodable = AnyCodable(SomeCodable(
       string: "String",
       int: 100,
       bool: true,
-      hasUnderscore: "another string"
+      hasUnderscore: "another string",
     ))
 
     let injectedValue = 1234
@@ -113,7 +116,7 @@ struct AnyCodableTests {
 
     // when
     let json = try encoder.encode(dictionary)
-    let encodedJSONObject = try JSONSerialization.jsonObject(with: json) as! NSDictionary
+    let encodedJSONObject = try #require(try JSONSerialization.jsonObject(with: json) as? NSDictionary)
 
     // then
     let expected = """
@@ -138,7 +141,7 @@ struct AnyCodableTests {
           "null": null
       }
       """.data(using: .utf8)!
-    let expectedJSONObject = try JSONSerialization.jsonObject(with: expected) as! NSDictionary
+    let expectedJSONObject = try #require(try JSONSerialization.jsonObject(with: expected) as? NSDictionary)
 
     #expect(encodedJSONObject == expectedJSONObject)
   }

--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyDecodableTests.swift
@@ -5,12 +5,13 @@
 //  Created by Elon on 4/9/25.
 //
 
-import Testing
 import Foundation
+import Testing
 @testable import KarrotCodableKit
 
 struct AnyDecodableTests {
-  @Test func testJSONDecoding() throws {
+  @Test
+  func `JSON decoding`() throws {
     // given
     let json = """
       {
@@ -33,12 +34,12 @@ struct AnyDecodableTests {
     let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
 
     // then
-    #expect(dictionary["boolean"]?.value as! Bool == true)
-    #expect(dictionary["integer"]?.value as! Int == 42)
-    #expect(abs(dictionary["double"]?.value as! Double - 3.141592653589793) < 0.001)
-    #expect(dictionary["string"]?.value as! String == "string")
-    #expect(dictionary["array"]?.value as! [Int] == [1, 2, 3])
-    #expect(dictionary["nested"]?.value as! [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
-    #expect(dictionary["null"]?.value as! NSNull == NSNull())
+    #expect(dictionary["boolean"]?.value as? Bool == true)
+    #expect(dictionary["integer"]?.value as? Int == 42)
+    #expect(abs(try #require(dictionary["double"]?.value as? Double) - 3.141592653589793) < 0.001)
+    #expect(dictionary["string"]?.value as? String == "string")
+    #expect(dictionary["array"]?.value as? [Int] == [1, 2, 3])
+    #expect(dictionary["nested"]?.value as? [String: String] == ["a": "alpha", "b": "bravo", "c": "charlie"])
+    #expect(dictionary["null"]?.value as? NSNull == NSNull())
   }
 }

--- a/Tests/KarrotCodableKitTests/AnyCodable/AnyEncodableTests.swift
+++ b/Tests/KarrotCodableKitTests/AnyCodable/AnyEncodableTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 4/9/25.
 //
 
-import Testing
 import Foundation
+import Testing
 @testable import KarrotCodableKit
 
 struct AnyEncodableTests {
@@ -19,13 +19,14 @@ struct AnyEncodableTests {
     var hasUnderscore: String
   }
 
-  @Test func testJSONEncoding() throws {
+  @Test
+  func `JSON encoding`() throws {
     // given
     let someEncodable = AnyEncodable(SomeEncodable(
       string: "String",
       int: 100,
       bool: true,
-      hasUnderscore: "another string"
+      hasUnderscore: "another string",
     ))
 
     let dictionary: [String: AnyEncodable] = [
@@ -46,7 +47,7 @@ struct AnyEncodableTests {
 
     // when
     let json = try encoder.encode(dictionary)
-    let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+    let encodedJSONObject = try #require(try JSONSerialization.jsonObject(with: json, options: []) as? NSDictionary)
 
     // then
     let expected = """
@@ -70,12 +71,16 @@ struct AnyEncodableTests {
           "null": null
       }
       """.data(using: .utf8)!
-    let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+    let expectedJSONObject = try #require(try JSONSerialization.jsonObject(
+      with: expected,
+      options: [],
+    ) as? NSDictionary)
 
     #expect(encodedJSONObject == expectedJSONObject)
   }
 
-  @Test func testEncodeNSNumber() throws {
+  @Test
+  func `encode NS number`() throws {
     // given
     let dictionary: [String: NSNumber] = [
       "boolean": true,
@@ -95,7 +100,7 @@ struct AnyEncodableTests {
 
     // when
     let json = try encoder.encode(AnyEncodable(dictionary))
-    let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+    let encodedJSONObject = try #require(try JSONSerialization.jsonObject(with: json, options: []) as? NSDictionary)
 
     // then
     let expected = """
@@ -114,7 +119,10 @@ struct AnyEncodableTests {
           "double": 3.141592653589793,
       }
       """.data(using: .utf8)!
-    let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+    let expectedJSONObject = try #require(try JSONSerialization.jsonObject(
+      with: expected,
+      options: [],
+    ) as? NSDictionary)
 
     #expect(encodedJSONObject == expectedJSONObject)
     #expect(encodedJSONObject["boolean"] is Bool)
@@ -134,7 +142,8 @@ struct AnyEncodableTests {
     #expect(encodedJSONObject["double"] is Double)
   }
 
-  @Test func testStringInterpolationEncoding() throws {
+  @Test
+  func `string interpolation encoding`() throws {
     // given
     let dictionary: [String: AnyEncodable] = [
       "boolean": "\(true)",
@@ -147,7 +156,7 @@ struct AnyEncodableTests {
 
     // when
     let json = try encoder.encode(dictionary)
-    let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+    let encodedJSONObject = try #require(try JSONSerialization.jsonObject(with: json, options: []) as? NSDictionary)
 
     // then
     let expected = """
@@ -159,7 +168,10 @@ struct AnyEncodableTests {
           "array": "[1, 2, 3]",
       }
       """.data(using: .utf8)!
-    let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+    let expectedJSONObject = try #require(try JSONSerialization.jsonObject(
+      with: expected,
+      options: [],
+    ) as? NSDictionary)
 
     #expect(encodedJSONObject == expectedJSONObject)
   }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueResilientTests.swift
@@ -16,8 +16,8 @@ struct DataValueResilientTests {
     @DataValue<Base64Strategy> var anotherData: Data
   }
 
-  @Test("projected value provides error information")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information`() throws {
     let json = """
       {
         "base64Data": "SGVsbG8gV29ybGQ=",
@@ -40,8 +40,8 @@ struct DataValueResilientTests {
     #endif
   }
 
-  @Test("invalid base64 format handling")
-  func invalidBase64Format() async throws {
+  @Test
+  func `invalid base64 format handling`() async throws {
     let json = """
       {
         "base64Data": "Invalid!@#$%^&*()Base64",
@@ -63,8 +63,8 @@ struct DataValueResilientTests {
     }
   }
 
-  @Test("null values handling")
-  func nullValues() async throws {
+  @Test
+  func `null values handling`() async throws {
     let json = """
       {
         "base64Data": null,
@@ -86,8 +86,8 @@ struct DataValueResilientTests {
     }
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() async throws {
+  @Test
+  func `error reporting with JSONDecoder`() async throws {
     let json = """
       {
         "base64Data": 12345,

--- a/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DataValue/DataValueTests.swift
@@ -5,13 +5,14 @@
 //  Created by Elon on 4/9/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct DataValueTests {
-  @Test func testDecodingAndEncodingBase64String() throws {
+  @Test
+  func `decoding and encoding base 64 string`() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: Data
@@ -31,7 +32,8 @@ struct DataValueTests {
     #expect(outputJSON == jsonData)
   }
 
-  @Test func testDecodingMalformedBase64Fails() throws {
+  @Test
+  func `decoding malformed base 64 fails`() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: Data
@@ -42,7 +44,8 @@ struct DataValueTests {
     #expect(throws: (any Error).self) { try JSONDecoder().decode(Fixture.self, from: jsonData) }
   }
 
-  @Test func testDecodingAndEncodingBase64StringToArray() throws {
+  @Test
+  func `decoding and encoding base 64 string to array`() throws {
     // given
     struct Fixture: Codable {
       @DataValue<Base64Strategy> var data: [UInt8]

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueResilientTests.swift
@@ -17,8 +17,8 @@ struct DateValueResilientTests {
     @DateValue<TimestampStrategy> var timestampDate: Date
   }
 
-  @Test("projected value provides error information")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information`() throws {
     let json = """
       {
         "isoDate": "2025-01-01T12:00:00Z",
@@ -44,8 +44,8 @@ struct DateValueResilientTests {
     #endif
   }
 
-  @Test("invalid date format handling")
-  func invalidDateFormat() async throws {
+  @Test
+  func `invalid date format handling`() async throws {
     let json = """
       {
         "isoDate": "invalid-date",
@@ -68,8 +68,8 @@ struct DateValueResilientTests {
     }
   }
 
-  @Test("null values handling")
-  func nullValues() async throws {
+  @Test
+  func `null values handling`() async throws {
     let json = """
       {
         "isoDate": null,
@@ -92,8 +92,8 @@ struct DateValueResilientTests {
     }
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() async throws {
+  @Test
+  func `error reporting with JSONDecoder`() async throws {
     let json = """
       {
         "isoDate": 12345,

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/DateValueTests.swift
@@ -5,13 +5,14 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct DateValueTests {
-  @Test func testDecodingAndEncodingISO8601DateString() throws {
+  @Test
+  func `decoding and encoding ISO 8601 date string`() throws {
     struct Fixture: Codable {
       @DateValue<ISO8601Strategy> var iso8601: Date
     }
@@ -26,7 +27,8 @@ struct DateValueTests {
     #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
+  @Test
+  func `decoding and encoding ISO 8601 date string with fractional seconds`() throws {
     struct Fixture: Codable {
       @DateValue<ISO8601WithFractionalSecondsStrategy> var iso8601: Date
       @DateValue<ISO8601WithFractionalSecondsStrategy> var iso8601Short: Date
@@ -48,7 +50,8 @@ struct DateValueTests {
     #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851013597.123))
   }
 
-  @Test func testDecodingAndEncodingRFC3339DateString() throws {
+  @Test
+  func `decoding and encoding RFC 3339 date string`() throws {
     struct Fixture: Codable {
       @DateValue<RFC3339Strategy> var rfc3339Date: Date
     }
@@ -63,7 +66,8 @@ struct DateValueTests {
     #expect(fixture.rfc3339Date == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingRFC3339NanoDateString() throws {
+  @Test
+  func `decoding RFC 3339 nano date string`() throws {
     struct Fixture: Codable {
       @DateValue<RFC3339NanoStrategy> var rfc3339Date1: Date
       @DateValue<RFC3339NanoStrategy> var rfc3339Date2: Date
@@ -97,7 +101,8 @@ struct DateValueTests {
     #expect(fixture.rfc3339Date6 == Date(timeIntervalSince1970: 1715082540.000))
   }
 
-  @Test func testEncodingRFC3339NanoDateToString() throws {
+  @Test
+  func `encoding RFC 3339 nano date to string`() {
     // given
     let date = Date(timeIntervalSince1970: 1720588949.481)
 
@@ -108,7 +113,8 @@ struct DateValueTests {
     #expect(result == "2024-07-10T05:22:29.481000Z")
   }
 
-  @Test func testDecodingAndEncodingUTCTimestamp() throws {
+  @Test
+  func `decoding and encoding UTC timestamp`() throws {
     struct Fixture: Codable {
       @DateValue<TimestampStrategy> var timestamp: Date
     }
@@ -118,7 +124,8 @@ struct DateValueTests {
     #expect(fixture.timestamp == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingAndEncodingWithCustomStrategies() throws {
+  @Test
+  func `decoding and encoding with custom strategies`() throws {
     struct Fixture: Codable {
       @DateValue<TimestampStrategy> var timeStamp: Date
     }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueOmitNilTests.swift
@@ -17,7 +17,7 @@ struct OptionalDateValueOmitNilTests {
   }
 
   @Test
-  func encodingNilOmitsKey() throws {
+  func `encoding nil omits key`() throws {
     // given
     let fixture = Fixture(iso8601: nil)
 
@@ -32,7 +32,7 @@ struct OptionalDateValueOmitNilTests {
   }
 
   @Test
-  func encodingValuePreservesKey() throws {
+  func `encoding value preserves key`() throws {
     // given
     let fixture = Fixture(iso8601: Date(timeIntervalSince1970: 851042397))
 
@@ -43,16 +43,16 @@ struct OptionalDateValueOmitNilTests {
 
     // then - a present value is still encoded under its key
     let expectResult = #"""
-    {
-      "iso8601" : "1996-12-20T00:39:57Z"
-    }
-    """#
+      {
+        "iso8601" : "1996-12-20T00:39:57Z"
+      }
+      """#
     let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
   }
 
   @Test
-  func encodingDecodingNilRoundTrip() throws {
+  func `encoding decoding nil round trip`() throws {
     // given
     let fixture = Fixture(iso8601: nil)
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueResilientTests.swift
@@ -21,12 +21,12 @@ struct OptionalDateValueResilientTests {
 
   // MARK: - ISO8601Strategy Tests
 
-  @Test("ISO8601Strategy: missing key sets outcome to keyNotFound")
-  func iso8601MissingKeyOutcome() throws {
+  @Test
+  func `ISO8601Strategy: missing key sets outcome to keyNotFound`() throws {
     let json = "{}"
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(ISO8601Fixture.self, from: data)
 
     // Should decode successfully with nil value
@@ -39,8 +39,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("ISO8601Strategy: null value sets outcome to valueWasNil")
-  func iso8601NullValueOutcome() throws {
+  @Test
+  func `ISO8601Strategy: null value sets outcome to valueWasNil`() throws {
     let json = """
       {
         "dateValue": null
@@ -48,7 +48,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(ISO8601Fixture.self, from: data)
 
     // Should decode successfully with nil value
@@ -61,8 +61,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("ISO8601Strategy: valid value sets outcome to decodedSuccessfully")
-  func iso8601ValidValueOutcome() throws {
+  @Test
+  func `ISO8601Strategy: valid value sets outcome to decodedSuccessfully`() throws {
     let json = """
       {
         "dateValue": "1996-12-19T16:39:57-08:00"
@@ -70,7 +70,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(ISO8601Fixture.self, from: data)
 
     // Should decode successfully with expected date
@@ -84,8 +84,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("ISO8601Strategy: invalid format throws error")
-  func iso8601InvalidFormatThrows() throws {
+  @Test
+  func `ISO8601Strategy: invalid format throws error`() throws {
     let json = """
       {
         "dateValue": "invalid-date-format"
@@ -93,7 +93,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
 
     // Should throw error for invalid format
     #expect(throws: DecodingError.self) {
@@ -101,8 +101,8 @@ struct OptionalDateValueResilientTests {
     }
   }
 
-  @Test("ISO8601Strategy: type mismatch throws error")
-  func iso8601TypeMismatchThrows() throws {
+  @Test
+  func `ISO8601Strategy: type mismatch throws error`() throws {
     let json = """
       {
         "dateValue": 123456789
@@ -110,7 +110,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
 
     // Should throw error for type mismatch
     #expect(throws: DecodingError.self) {
@@ -120,12 +120,12 @@ struct OptionalDateValueResilientTests {
 
   // MARK: - TimestampStrategy Tests
 
-  @Test("TimestampStrategy: missing key sets outcome to keyNotFound")
-  func timestampMissingKeyOutcome() throws {
+  @Test
+  func `TimestampStrategy: missing key sets outcome to keyNotFound`() throws {
     let json = "{}"
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(TimestampFixture.self, from: data)
 
     // Should decode successfully with nil value
@@ -138,8 +138,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("TimestampStrategy: null value sets outcome to valueWasNil")
-  func timestampNullValueOutcome() throws {
+  @Test
+  func `TimestampStrategy: null value sets outcome to valueWasNil`() throws {
     let json = """
       {
         "dateValue": null
@@ -147,7 +147,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(TimestampFixture.self, from: data)
 
     // Should decode successfully with nil value
@@ -160,8 +160,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("TimestampStrategy: valid value sets outcome to decodedSuccessfully")
-  func timestampValidValueOutcome() throws {
+  @Test
+  func `TimestampStrategy: valid value sets outcome to decodedSuccessfully`() throws {
     let json = """
       {
         "dateValue": 851042397.0
@@ -169,7 +169,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(TimestampFixture.self, from: data)
 
     // Should decode successfully with expected date
@@ -183,8 +183,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("TimestampStrategy: integer timestamp works")
-  func timestampIntegerValueOutcome() throws {
+  @Test
+  func `TimestampStrategy: integer timestamp works`() throws {
     let json = """
       {
         "dateValue": 851042397
@@ -192,7 +192,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(TimestampFixture.self, from: data)
 
     // Should decode successfully with expected date
@@ -206,8 +206,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("TimestampStrategy: type mismatch throws error")
-  func timestampTypeMismatchThrows() throws {
+  @Test
+  func `TimestampStrategy: type mismatch throws error`() throws {
     let json = """
       {
         "dateValue": "not-a-number"
@@ -215,7 +215,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
 
     // Should throw error for type mismatch
     #expect(throws: DecodingError.self) {
@@ -225,12 +225,12 @@ struct OptionalDateValueResilientTests {
 
   // MARK: - Direct Decoder Tests (Resilient Behavior Works)
 
-  @Test("Direct single value decoding with nil works correctly")
-  func directSingleValueDecodingNil() throws {
+  @Test
+  func `Direct single value decoding with nil works correctly`() throws {
     // When decoding directly from a single value container, resilient behavior works
     let json = "null"
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
 
     let dateValue = try decoder.decode(OptionalDateValue<ISO8601Strategy>.self, from: data)
 
@@ -243,12 +243,12 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("Direct single value decoding with missing key throws error")
-  func directSingleValueDecodingMissingKey() throws {
+  @Test
+  func `Direct single value decoding with missing key throws error`() throws {
     // When a key is truly missing in single value context, it throws
     let json = "{}"
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
 
     #expect(throws: DecodingError.self) {
       _ = try decoder.decode(OptionalDateValue<ISO8601Strategy>.self, from: data)
@@ -257,8 +257,8 @@ struct OptionalDateValueResilientTests {
 
   // MARK: - Mixed Strategy Tests
 
-  @Test("Combined strategies work correctly in same fixture")
-  func combinedStrategiesOutcome() throws {
+  @Test
+  func `Combined strategies work correctly in same fixture`() throws {
     struct CombinedFixture: Decodable {
       @OptionalDateValue<ISO8601Strategy> var isoDate: Date?
       @OptionalDateValue<TimestampStrategy> var timestampDate: Date?
@@ -272,7 +272,7 @@ struct OptionalDateValueResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(CombinedFixture.self, from: data)
 
     // Should decode ISO date successfully and timestamp as nil
@@ -290,8 +290,8 @@ struct OptionalDateValueResilientTests {
     #endif
   }
 
-  @Test("All missing keys scenario")
-  func allMissingKeysOutcome() throws {
+  @Test
+  func `All missing keys scenario`() throws {
     struct CombinedFixture: Decodable {
       @OptionalDateValue<ISO8601Strategy> var isoDate: Date?
       @OptionalDateValue<TimestampStrategy> var timestampDate: Date?
@@ -300,7 +300,7 @@ struct OptionalDateValueResilientTests {
     let json = "{}"
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(CombinedFixture.self, from: data)
 
     // Both should be nil

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/OptionalDateValueTests.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2024 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct OptionalDateValueTests {
 
-  @Test func testDecodingAndEncodingISO8601DateString() throws {
+  @Test
+  func `decoding and encoding ISO 8601 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -28,7 +29,8 @@ struct OptionalDateValueTests {
     #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingAndEncodingOptionalISO8601DateString() throws {
+  @Test
+  func `decoding and encoding optional ISO 8601 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -43,7 +45,8 @@ struct OptionalDateValueTests {
     #expect(fixture.iso8601 == nil)
   }
 
-  @Test func testDecodingAndEncodingNotPresentISO8601DateString() throws {
+  @Test
+  func `decoding and encoding not present ISO 8601 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601Strategy> var iso8601: Date?
     }
@@ -58,7 +61,8 @@ struct OptionalDateValueTests {
     #expect(fixture.iso8601 == nil)
   }
 
-  @Test func testDecodingAndEncodingISO8601DateStringWithFractionalSeconds() throws {
+  @Test
+  func `decoding and encoding ISO 8601 date string with fractional seconds`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<ISO8601WithFractionalSecondsStrategy> var iso8601: Date?
       @OptionalDateValue<ISO8601WithFractionalSecondsStrategy> var iso8601Short: Date?
@@ -80,7 +84,8 @@ struct OptionalDateValueTests {
     #expect(fixture.iso8601 == Date(timeIntervalSince1970: 851013597.123))
   }
 
-  @Test func testDecodingAndEncodingRFC3339DateString() throws {
+  @Test
+  func `decoding and encoding RFC 3339 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -95,7 +100,8 @@ struct OptionalDateValueTests {
     #expect(fixture.rfc3339Date == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingAndEncodingOptionalRFC3339DateString() throws {
+  @Test
+  func `decoding and encoding optional RFC 3339 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -110,7 +116,8 @@ struct OptionalDateValueTests {
     #expect(fixture.rfc3339Date == nil)
   }
 
-  @Test func testDecodingAndEncodingNotPresentRFC3339DateString() throws {
+  @Test
+  func `decoding and encoding not present RFC 3339 date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339Strategy> var rfc3339Date: Date?
     }
@@ -125,7 +132,8 @@ struct OptionalDateValueTests {
     #expect(fixture.rfc3339Date == nil)
   }
 
-  @Test func testDecodingRFC3339NanoDateString() throws {
+  @Test
+  func `decoding RFC 3339 nano date string`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<RFC3339NanoStrategy> var rfc3339Date1: Date?
       @OptionalDateValue<RFC3339NanoStrategy> var rfc3339Date2: Date?
@@ -159,7 +167,8 @@ struct OptionalDateValueTests {
     #expect(fixture.rfc3339Date6 == Date(timeIntervalSince1970: 1715082540.000))
   }
 
-  @Test func testDecodingAndEncodingUTCTimestamp() throws {
+  @Test
+  func `decoding and encoding UTC timestamp`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timestamp: Date?
     }
@@ -174,7 +183,8 @@ struct OptionalDateValueTests {
     #expect(fixture.timestamp == Date(timeIntervalSince1970: 851042397))
   }
 
-  @Test func testDecodingAndEncodingOptionalUTCTimestamp() throws {
+  @Test
+  func `decoding and encoding optional UTC timestamp`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timestamp: Date?
     }
@@ -189,7 +199,8 @@ struct OptionalDateValueTests {
     #expect(fixture.timestamp == nil)
   }
 
-  @Test func testDecodingAndEncodingWithCustomStrategies() throws {
+  @Test
+  func `decoding and encoding with custom strategies`() throws {
     struct Fixture: Codable {
       @OptionalDateValue<TimestampStrategy> var timeStamp: Date?
     }

--- a/Tests/KarrotCodableKitTests/BetterCodable/DateValue/RFC3339StrategyTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/DateValue/RFC3339StrategyTests.swift
@@ -23,7 +23,7 @@ struct RFC3339StrategyTests {
 extension RFC3339StrategyTests {
 
   @Test
-  func encodesUTCDateWithZOffsetInsteadOfRFC822Offset() {
+  func `encodes UTC date with Z offset instead of RFC 822 offset`() {
     // given
     let date = Date(timeIntervalSince1970: 1715082540) // 2024-05-07T11:49:00 UTC
 
@@ -36,7 +36,7 @@ extension RFC3339StrategyTests {
   }
 
   @Test
-  func serializesUTCDateWithZOffsetViaJSONEncoder() throws {
+  func `serializes UTC date with Z offset via JSON encoder`() throws {
     // given
     let date = Date(timeIntervalSince1970: 1715082540) // 2024-05-07T11:49:00 UTC
     let fixture = Fixture(date: date)
@@ -58,9 +58,9 @@ extension RFC3339StrategyTests {
   @Test(arguments: [
     "2024-05-07T11:49:00Z",
     "2024-05-07T11:49:00+00:00",
-    "2024-05-07T11:49:00+0000"
+    "2024-05-07T11:49:00+0000",
   ])
-  func decodesEveryUTCOffsetFormToSameInstant(input: String) throws {
+  func `decodes every UTC offset form to same instant`(input: String) throws {
     // when
     let date = try RFC3339Strategy.decode(input)
 
@@ -71,9 +71,9 @@ extension RFC3339StrategyTests {
 
   @Test(arguments: [
     "1996-12-19T16:39:57-08:00",
-    "1996-12-19T16:39:57-0800"
+    "1996-12-19T16:39:57-0800",
   ])
-  func decodesNonUTCOffsetsWithOrWithoutColon(input: String) throws {
+  func `decodes non UTC offsets with or without colon`(input: String) throws {
     // when
     let date = try RFC3339Strategy.decode(input)
 
@@ -87,7 +87,7 @@ extension RFC3339StrategyTests {
 extension RFC3339StrategyTests {
 
   @Test
-  func throwsDataCorruptedErrorForMalformedString() {
+  func `throws data corrupted error for malformed string`() {
     // when / then
     #expect {
       try RFC3339Strategy.decode("not-a-valid-date")

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaulEmptyDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaulEmptyDictionaryTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -15,7 +15,8 @@ struct DefaultEmptyDictionaryTests {
     @DefaultEmptyDictionary var stringToInt: [String: Int]
   }
 
-  @Test func testDecodingFailableDictionaryDefaultsToEmptyDictionary() throws {
+  @Test
+  func `decoding failable dictionary defaults to empty dictionary`() throws {
     // given
     let jsonData = #"{ "stringToInt": null }"#.data(using: .utf8)!
 
@@ -26,7 +27,8 @@ struct DefaultEmptyDictionaryTests {
     #expect(fixture.stringToInt == [:])
   }
 
-  @Test func testDecodingKeyNotPresentDefaultsToEmptyDictionary() throws {
+  @Test
+  func `decoding key not present defaults to empty dictionary`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -37,7 +39,8 @@ struct DefaultEmptyDictionaryTests {
     #expect(fixture.stringToInt == [:])
   }
 
-  @Test func testEncodingDecodedFailableDictionaryDefaultsToEmptyDictionary() throws {
+  @Test
+  func `encoding decoded failable dictionary defaults to empty dictionary`() throws {
     // given
     let jsonData = #"{ "stringToInt": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -51,7 +54,8 @@ struct DefaultEmptyDictionaryTests {
     #expect(fixture.stringToInt == ["one": 1])
   }
 
-  @Test func testEncodingDecodedFulfillableDictionaryRetainsContents() throws {
+  @Test
+  func `encoding decoded fulfillable dictionary retains contents`() throws {
     // given
     let jsonData = #"{ "stringToInt": {"one": 1, "two": 2} }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableResilientTests.swift
@@ -19,8 +19,8 @@ struct DefaultCodableResilientTests {
     @DefaultEmptyDictionary var dictValue: [String: Int]
   }
 
-  @Test("projected value provides error information for failed decoding")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information for failed decoding`() throws {
     let json = """
       {
         "intValue": "not a number",
@@ -32,7 +32,7 @@ struct DefaultCodableResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(Fixture.self, from: data)
 
     // Verify default behavior - use default value on decoding failure
@@ -62,12 +62,12 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("missing keys use default values without error")
-  func missingKeysUseDefaultValues() throws {
+  @Test
+  func `missing keys use default values without error`() throws {
     let json = "{}"
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(Fixture.self, from: data)
 
     // Check default values
@@ -87,8 +87,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("valid values decode successfully")
-  func validValuesDecodeSuccessfully() throws {
+  @Test
+  func `valid values decode successfully`() throws {
     let json = """
       {
         "intValue": 42,
@@ -100,7 +100,7 @@ struct DefaultCodableResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(Fixture.self, from: data)
 
     // Check normal values
@@ -120,8 +120,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("null values use default values")
-  func nullValuesUseDefaultValues() throws {
+  @Test
+  func `null values use default values`() throws {
     let json = """
       {
         "intValue": null,
@@ -133,7 +133,7 @@ struct DefaultCodableResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(Fixture.self, from: data)
 
     // Use default value for null
@@ -153,8 +153,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReportingWithDecoder() throws {
+  @Test
+  func `error reporting with JSONDecoder`() throws {
     let json = """
       {
         "intValue": "invalid",
@@ -166,7 +166,7 @@ struct DefaultCodableResilientTests {
     let decoder = JSONDecoder()
     let errorReporter = decoder.enableResilientDecodingErrorReporting()
 
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     _ = try decoder.decode(Fixture.self, from: data)
 
     let errorDigest = errorReporter.flushReportedErrors()
@@ -181,8 +181,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("LossyOptional behavior")
-  func lossyOptional() throws {
+  @Test
+  func `LossyOptional behavior`() throws {
     struct OptionalFixture: Decodable {
       @LossyOptional var url: URL?
       @LossyOptional var date: Date?
@@ -198,7 +198,7 @@ struct DefaultCodableResilientTests {
       """
 
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(OptionalFixture.self, from: data)
 
     // nil on decoding failure
@@ -238,8 +238,8 @@ struct DefaultCodableResilientTests {
     @DefaultCodable<FrozenTestEnum> var frozenEnum: FrozenTestEnum
   }
 
-  @Test("RawRepresentable with valid raw values")
-  func rawRepresentableValidValues() throws {
+  @Test
+  func `RawRepresentable with valid raw values`() throws {
     // given
     let json = """
       {
@@ -250,7 +250,7 @@ struct DefaultCodableResilientTests {
 
     // when
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then
@@ -265,8 +265,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("RawRepresentable with unknown raw values (non-frozen)")
-  func rawRepresentableUnknownValueNonFrozen() throws {
+  @Test
+  func `RawRepresentable with unknown raw values (non-frozen)`() throws {
     // given
     let json = """
       {
@@ -277,7 +277,7 @@ struct DefaultCodableResilientTests {
 
     // when
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then
@@ -295,8 +295,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("RawRepresentable with unknown raw values (frozen)")
-  func rawRepresentableUnknownValueFrozen() throws {
+  @Test
+  func `RawRepresentable with unknown raw values (frozen)`() throws {
     // given
     let json = """
       {
@@ -308,7 +308,7 @@ struct DefaultCodableResilientTests {
     // when
     let decoder = JSONDecoder()
     let errorReporter = decoder.enableResilientDecodingErrorReporting()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then
@@ -334,14 +334,14 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("RawRepresentable with missing keys")
-  func rawRepresentableMissingKeys() throws {
+  @Test
+  func `RawRepresentable with missing keys`() throws {
     // given
     let json = "{}"
 
     // when
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then
@@ -356,8 +356,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("RawRepresentable with null values")
-  func rawRepresentableNullValues() throws {
+  @Test
+  func `RawRepresentable with null values`() throws {
     // given
     let json = """
       {
@@ -368,7 +368,7 @@ struct DefaultCodableResilientTests {
 
     // when
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then
@@ -383,8 +383,8 @@ struct DefaultCodableResilientTests {
     #endif
   }
 
-  @Test("RawRepresentable with type mismatch")
-  func rawRepresentableTypeMismatch() throws {
+  @Test
+  func `RawRepresentable with type mismatch`() throws {
     // given - enums expect String but we provide numbers
     let json = """
       {
@@ -395,7 +395,7 @@ struct DefaultCodableResilientTests {
 
     // when
     let decoder = JSONDecoder()
-    let data = json.data(using: .utf8)!
+    let data = try #require(json.data(using: .utf8))
     let fixture = try decoder.decode(RawRepresentableFixture.self, from: data)
 
     // then

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultCodableTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -48,7 +48,8 @@ struct DefaultCodableTest_DateStrategy {
     fileprivate var discoverDate: Date
   }
 
-  @Test func testDecodingAndEncodingWithDateStrategy() throws {
+  @Test
+  func `decoding and encoding with date strategy`() throws {
     let expectedDate = Date(timeIntervalSinceReferenceDate: 222601260)
     let jsonData = #"{ "discoverDate": "2008-01-21T09:41:00.000Z" }"#.data(using: .utf8)!
     let fixture = try JSONDecoder.iso.decode(Fixture.self, from: jsonData)
@@ -75,7 +76,8 @@ struct DefaultCodableTest_NestedPropertyWrapper {
     var returnDate: Date
   }
 
-  @Test func testNestedPropertyWrappersCanMergeDefaultCodableWithDateStrategy() throws {
+  @Test
+  func `nested property wrappers can merge default codable with date strategy`() throws {
     let _1970 = Date(timeIntervalSince1970: 0)
     let _1971 = Date(timeIntervalSince1970: 31536000)
 
@@ -122,7 +124,8 @@ struct DefaultCodableTests_TypesWithContainers {
     public var type: DictionaryContainer
   }
 
-  @Test func testDecodingAndEncodingWithArrayContainer() throws {
+  @Test
+  func `decoding and encoding with array container`() throws {
     let jsonData = #"{ "type": { "value": [2, 4, 6] } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
     #expect(fixture.type.value == [2, 4, 6])
@@ -132,7 +135,8 @@ struct DefaultCodableTests_TypesWithContainers {
     #expect(str == #"{"type":{"value":[2,4,6]}}"#)
   }
 
-  @Test func testDecodingAndEncodingWithDictionaryContainer() throws {
+  @Test
+  func `decoding and encoding with dictionary container`() throws {
     let jsonData = #"{ "type": { "value": {"b": 17 } } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture2.self, from: jsonData)
     #expect(fixture.type.value == ["b": 17])
@@ -168,8 +172,8 @@ struct DefaultCodableTests_EnumWithAssociatedValue {
       let k = try c.decode(String.self, forKey: .z)
       let i = try c.decode(Int.self, forKey: .i)
 
-      if k == "ziz" { self.z = .ziz(i) }
-      else { self.z = .zaz(i) }
+      if k == "ziz" { z = .ziz(i) }
+      else { z = .zaz(i) }
     }
 
     func encode(to encoder: Encoder) throws {
@@ -195,7 +199,8 @@ struct DefaultCodableTests_EnumWithAssociatedValue {
     public var value: CustomType
   }
 
-  @Test func testDecodingAndEncodingCustomEnumWithAssociatedValue() throws {
+  @Test
+  func `decoding and encoding custom enum with associated value`() throws {
     let jsonData = #"{ "value": { "fish": "ziz", "int": 4 } }"#.data(using: .utf8)!
     let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
     #expect(fixture.value.z == .ziz(4))

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyArrayTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -21,7 +21,8 @@ struct DefaultEmptyArrayTests {
     @DefaultEmptyArray var nonPrimitiveValues: [NestedFixture]
   }
 
-  @Test func testDecodingFailableArrayDefaultsToEmptyArray() throws {
+  @Test
+  func `decoding failable array defaults to empty array`() throws {
     // given
     let jsonData = #"{ "values": null, "nonPrimitiveValues": null }"#.data(using: .utf8)!
 
@@ -33,7 +34,8 @@ struct DefaultEmptyArrayTests {
     #expect(fixture.nonPrimitiveValues == [])
   }
 
-  @Test func testDecodingKeyNotPresentDefaultsToEmptyArray() throws {
+  @Test
+  func `decoding key not present defaults to empty array`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -45,7 +47,8 @@ struct DefaultEmptyArrayTests {
     #expect(fixture.nonPrimitiveValues == [])
   }
 
-  @Test func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
+  @Test
+  func `encoding decoded failable array defaults to empty array`() throws {
     // given
     let jsonData = #"{ "values": null, "nonPrimitiveValues": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -61,7 +64,8 @@ struct DefaultEmptyArrayTests {
     #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "a", two: ["b": ["c"]])])
   }
 
-  @Test func testEncodingDecodedFulfillableArrayRetainsContents() throws {
+  @Test
+  func `encoding decoded fulfillable array retains contents`() throws {
     // given
     let jsonData = #"{ "values": [1, 2], "nonPrimitiveValues": [{ "one": "one", "two": {"key": ["value"]}}] }"#
       .data(using: .utf8)!

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyStringTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultEmptyStringTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -16,7 +16,8 @@ struct DefaultEmptyStringTests {
     @DefaultEmptyString var string: String
   }
 
-  @Test func testDecodingFailableStringDefaultEmptyString() throws {
+  @Test
+  func `decoding failable string default empty string`() throws {
     // given
     let jsonData = #"{ "string": null }"#.data(using: .utf8)!
 
@@ -27,7 +28,8 @@ struct DefaultEmptyStringTests {
     #expect(fixture.string == "")
   }
 
-  @Test func testDecodingKeyNotPresentDefaultEmptyString() throws {
+  @Test
+  func `decoding key not present default empty string`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -38,7 +40,8 @@ struct DefaultEmptyStringTests {
     #expect(fixture.string == "")
   }
 
-  @Test func testDecodinSuccessDefaultEmptyString() throws {
+  @Test
+  func `decodin success default empty string`() throws {
     // given
     let jsonData = #"{ "string": "hi" }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultFalseTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultFalseTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -16,7 +16,8 @@ struct DefaultFalseTests {
     @DefaultFalse var truthy: Bool
   }
 
-  @Test func testDecodingFailableArrayDefaultsToFalse() throws {
+  @Test
+  func `decoding failable array defaults to false`() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
 
@@ -27,7 +28,8 @@ struct DefaultFalseTests {
     #expect(fixture.truthy == false)
   }
 
-  @Test func testDecodingKeyNotPresentDefaultsToFalse() throws {
+  @Test
+  func `decoding key not present defaults to false`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -38,7 +40,8 @@ struct DefaultFalseTests {
     #expect(fixture.truthy == false)
   }
 
-  @Test func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
+  @Test
+  func `encoding decoded failable array defaults to false`() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -52,7 +55,8 @@ struct DefaultFalseTests {
     #expect(fixture.truthy == true)
   }
 
-  @Test func testEncodingDecodedFulfillableBoolRetainsValue() throws {
+  @Test
+  func `encoding decoded fulfillable bool retains value`() throws {
     // given
     let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -65,7 +69,8 @@ struct DefaultFalseTests {
     #expect(fixture.truthy == true)
   }
 
-  @Test func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
+  @Test
+  func `decoding misaligned bool int value decodes correct bool value`() throws {
     // given
     let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
@@ -79,7 +84,8 @@ struct DefaultFalseTests {
     #expect(fixture2.truthy == false)
   }
 
-  @Test func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
+  @Test
+  func `decoding misaligned bool string value decodes correct bool value`() throws {
     // given
     let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!
@@ -93,7 +99,8 @@ struct DefaultFalseTests {
     #expect(fixture2.truthy == false)
   }
 
-  @Test func testDecodingInvalidValueDecodesToDefaultValue() throws {
+  @Test
+  func `decoding invalid value decodes to default value`() throws {
     // given
     let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultTrueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultTrueTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -15,7 +15,8 @@ struct DefaultTrueTests {
     @DefaultTrue var truthy: Bool
   }
 
-  @Test func testDecodingFailableArrayDefaultsToFalse() throws {
+  @Test
+  func `decoding failable array defaults to false`() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
 
@@ -26,7 +27,8 @@ struct DefaultTrueTests {
     #expect(fixture.truthy == true)
   }
 
-  @Test func testDecodingKeyNotPresentDefaultsToFalse() throws {
+  @Test
+  func `decoding key not present defaults to false`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -37,7 +39,8 @@ struct DefaultTrueTests {
     #expect(fixture.truthy == true)
   }
 
-  @Test func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
+  @Test
+  func `encoding decoded failable array defaults to false`() throws {
     // given
     let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -51,7 +54,8 @@ struct DefaultTrueTests {
     #expect(fixture.truthy == false)
   }
 
-  @Test func testEncodingDecodedFulfillableBoolRetainsValue() throws {
+  @Test
+  func `encoding decoded fulfillable bool retains value`() throws {
     // given
     let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
     let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -64,7 +68,8 @@ struct DefaultTrueTests {
     #expect(fixture.truthy == true)
   }
 
-  @Test func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
+  @Test
+  func `decoding misaligned bool int value decodes correct bool value`() throws {
     // given
     let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
@@ -78,7 +83,8 @@ struct DefaultTrueTests {
     #expect(fixture2.truthy == false)
   }
 
-  @Test func testDecodingInvalidValueDecodesToDefaultValue() throws {
+  @Test
+  func `decoding invalid value decodes to default value`() throws {
     // given
     let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
 
@@ -89,7 +95,8 @@ struct DefaultTrueTests {
     #expect(fixture.truthy == true, "Should fall in to the else block and return default value")
   }
 
-  @Test func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
+  @Test
+  func `decoding misaligned bool string value decodes correct bool value`() throws {
     // given
     let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
     let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroDoubleTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroDoubleTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -16,7 +16,8 @@ struct DefaultZeroDoubleTests {
     @DefaultZeroDouble var doubleValue: Double
   }
 
-  @Test func testDecodingFailableDoubleDefaultZeroDouble() throws {
+  @Test
+  func `decoding failable double default zero double`() throws {
     // given
     let jsonData = #"{ "doubleValue": null }"#.data(using: .utf8)!
 
@@ -27,7 +28,8 @@ struct DefaultZeroDoubleTests {
     #expect(fixture.doubleValue == 0.0)
   }
 
-  @Test func testDecodingKeyNotPresentDefaultZeroDouble() throws {
+  @Test
+  func `decoding key not present default zero double`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -38,7 +40,8 @@ struct DefaultZeroDoubleTests {
     #expect(fixture.doubleValue == 0.0)
   }
 
-  @Test func testDecodinSuccessDefaultZeroDouble() throws {
+  @Test
+  func `decodin success default zero double`() throws {
     // given
     let jsonData = #"{ "doubleValue": 0.001 }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroFloatTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroFloatTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -16,7 +16,8 @@ struct DefaultZeroFloatTests {
     @DefaultZeroFloat var floatValue: Float
   }
 
-  @Test func testDecodingFailableFloatDefaultZeroFloat() throws {
+  @Test
+  func `decoding failable float default zero float`() throws {
     // given
     let jsonData = #"{ "floatValue": null }"#.data(using: .utf8)!
 
@@ -27,7 +28,8 @@ struct DefaultZeroFloatTests {
     #expect(fixture.floatValue == 0.0)
   }
 
-  @Test func testDecodingKeyNotPresentDefaultZeroFloat() throws {
+  @Test
+  func `decoding key not present default zero float`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -38,7 +40,8 @@ struct DefaultZeroFloatTests {
     #expect(fixture.floatValue == 0.0)
   }
 
-  @Test func testDecodinSuccessDefaultZeroFloat() throws {
+  @Test
+  func `decodin success default zero float`() throws {
     // given
     let jsonData = #"{ "floatValue": 0.001 }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroIntTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/Defaults/DefaultZeroIntTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/27.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -15,7 +15,8 @@ struct DefaultZeroIntTests {
     @DefaultZeroInt var intValue: Int
   }
 
-  @Test func testDecodingFailableIntDefaultZeroInt() throws {
+  @Test
+  func `decoding failable int default zero int`() throws {
     // given
     let jsonData = #"{ "intValue": null }"#.data(using: .utf8)!
 
@@ -26,7 +27,8 @@ struct DefaultZeroIntTests {
     #expect(fixture.intValue == 0)
   }
 
-  @Test func testDecodingKeyNotPresentDefaultZeroInt() throws {
+  @Test
+  func `decoding key not present default zero int`() throws {
     // given
     let jsonData = #"{}"#.data(using: .utf8)!
 
@@ -37,7 +39,8 @@ struct DefaultZeroIntTests {
     #expect(fixture.intValue == 0)
   }
 
-  @Test func testDecodinSuccessDefaultZeroInt() throws {
+  @Test
+  func `decodin success default zero int`() throws {
     // given
     let jsonData = #"{ "intValue": 999 }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayResilientTests.swift
@@ -24,8 +24,8 @@ struct LosslessArrayResilientTests {
     @LosslessArray var objectArray: [String] // Objects cannot be converted to String
   }
 
-  @Test("projected value provides error information for each failed element")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information for each failed element`() throws {
     let json = """
       {
         "stringArray": [1, "two", true, null, 5.5],
@@ -61,8 +61,8 @@ struct LosslessArrayResilientTests {
     #endif
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() throws {
+  @Test
+  func `error reporting with JSONDecoder`() throws {
     let json = """
       {
         "stringArray": [1, null, "three"],
@@ -91,8 +91,8 @@ struct LosslessArrayResilientTests {
     #endif
   }
 
-  @Test("complete failure results in empty array")
-  func completeFailure() async throws {
+  @Test
+  func `complete failure results in empty array`() async throws {
     let json = """
       {
         "stringArray": "not an array",
@@ -116,8 +116,8 @@ struct LosslessArrayResilientTests {
     }
   }
 
-  @Test("missing keys result in decoding error")
-  func missingKeys() async throws {
+  @Test
+  func `missing keys result in decoding error`() async throws {
     let json = "{}"
 
     let decoder = JSONDecoder()

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessArrayTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -19,7 +19,8 @@ struct LosslessArrayTests {
     @LosslessArray var values: [String]
   }
 
-  @Test func testDecodingLosslessArrayActsLikeLossyArray() throws {
+  @Test
+  func `decoding lossless array acts like lossy array`() throws {
     // given
     let jsonData = #"{ "values": [1, null, 3, 4] }"#.data(using: .utf8)!
 
@@ -30,7 +31,8 @@ struct LosslessArrayTests {
     #expect(fixture.values == [1, 3, 4])
   }
 
-  @Test func testDecodingIntsConvertsStringsIntoLosslessElements() throws {
+  @Test
+  func `decoding ints converts strings into lossless elements`() throws {
     // given
     let jsonData = #"{ "values": ["1", 2, null, "4"] }"#.data(using: .utf8)!
 
@@ -41,7 +43,8 @@ struct LosslessArrayTests {
     #expect(fixture.values == [1, 2, 4])
   }
 
-  @Test func testDecodingStringsPreservesLosslessElements() throws {
+  @Test
+  func `decoding strings preserves lossless elements`() throws {
     // given
     let jsonData = #"{ "values": ["1", 2, 3.14, null, false, "4"] }"#.data(using: .utf8)!
 
@@ -52,7 +55,8 @@ struct LosslessArrayTests {
     #expect(fixture.values == ["1", "2", "3.14", "false", "4"])
   }
 
-  @Test func testEncodingDecodedLosslessArrayIgnoresFailableElements() throws {
+  @Test
+  func `encoding decoded lossless array ignores failable elements`() throws {
     // given
     let jsonData = #"{ "values": [null, "2", null, 4] }"#.data(using: .utf8)!
 
@@ -70,7 +74,8 @@ struct LosslessArrayTests {
     #expect(fixture.values == [2, 4, 5])
   }
 
-  @Test func testEncodingDecodedLosslessArrayRetainsContents() throws {
+  @Test
+  func `encoding decoded lossless array retains contents`() throws {
     // given
     let jsonData = #"{ "values": [1, 2, "3"] }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessCustomValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessCustomValueTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -31,7 +31,8 @@ struct LosslessCustomValueTests {
     @MyLosslessType var bool: Bool
   }
 
-  @Test func testDecodingCustomLosslessStrategyDecodesCorrectly() throws {
+  @Test
+  func `decoding custom lossless strategy decodes correctly`() throws {
     // given
     let jsonData = #"{ "string": 7, "int": "1", "fortytwo": null, "bool": true }"#.data(using: .utf8)!
 
@@ -45,7 +46,8 @@ struct LosslessCustomValueTests {
     #expect(fixture.bool == true)
   }
 
-  @Test func testDecodingCustomLosslessStrategyWithBrokenFieldsThrowsError() throws {
+  @Test
+  func `decoding custom lossless strategy with broken fields throws error`() throws {
     // given
     let jsonData = #"{ "string": 7, "int": "1", "fortytwo": null, "bool": 9 }"#.data(using: .utf8)!
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueResilientTests.swift
@@ -18,8 +18,8 @@ struct LosslessValueResilientTests {
     @LosslessValue var doubleValue: Double
   }
 
-  @Test("projected value provides error information")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information`() throws {
     let json = """
       {
         "stringValue": 123,
@@ -48,8 +48,8 @@ struct LosslessValueResilientTests {
     #endif
   }
 
-  @Test("null values handling")
-  func nullValues() async throws {
+  @Test
+  func `null values handling`() async throws {
     let json = """
       {
         "stringValue": null,
@@ -73,8 +73,8 @@ struct LosslessValueResilientTests {
     }
   }
 
-  @Test("unconvertible values")
-  func unconvertibleValues() async throws {
+  @Test
+  func `unconvertible values`() async throws {
     let json = """
       {
         "stringValue": {"key": "value"},
@@ -98,8 +98,8 @@ struct LosslessValueResilientTests {
     }
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() async throws {
+  @Test
+  func `error reporting with JSONDecoder`() async throws {
     let json = """
       {
         "stringValue": {"key": "value"},

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/LosslessValueTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -18,7 +18,8 @@ struct LosslessValueTests {
     @LosslessValue var double: Double
   }
 
-  @Test func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
+  @Test
+  func `decoding misaligned types from JSON traverses correct type`() throws {
     // given
     let jsonData = #"{ "bool": "true", "string": 42, "int": "1", "double": "7.1" }"#.data(using: .utf8)!
 
@@ -32,7 +33,8 @@ struct LosslessValueTests {
     #expect(fixture.double == 7.1)
   }
 
-  @Test func testDecodingEncodedMisalignedTypesFromJSONDecodesCorrectTypes() throws {
+  @Test
+  func `decoding encoded misaligned types from JSON decodes correct types`() throws {
     // given
     let jsonData = #"{ "bool": "true", "string": 42, "int": "7", "double": "7.1" }"#.data(using: .utf8)!
 
@@ -54,7 +56,8 @@ struct LosslessValueTests {
     #expect(fixture.double == 3.14)
   }
 
-  @Test func testEncodingAndDecodedExpectedTypes() throws {
+  @Test
+  func `encoding and decoded expected types`() throws {
     // given
     let jsonData = #"{ "bool": true, "string": "42", "int": 7, "double": 7.1 }"#.data(using: .utf8)!
 
@@ -72,7 +75,8 @@ struct LosslessValueTests {
     #expect(fixture.double == 7.1)
   }
 
-  @Test func testDecodingBoolIntValueFromJSONDecodesCorrectly() throws {
+  @Test
+  func `decoding bool int value from JSON decodes correctly`() throws {
     struct FixtureWithBooleanAsInteger: Equatable, Codable {
       @LosslessBoolValue var bool: Bool
       @LosslessValue var string: String
@@ -97,7 +101,8 @@ struct LosslessValueTests {
     #expect(fixture.double == 7.1)
   }
 
-  @Test func testBoolAsIntegerShouldNotConflictWithDefaultStrategy() throws {
+  @Test
+  func `bool as integer should not conflict with default strategy`() throws {
     struct Response: Codable {
       @LosslessValue var id: String
       @LosslessBoolValue var bool: Bool
@@ -114,7 +119,8 @@ struct LosslessValueTests {
     #expect(result.bool == true)
   }
 
-  @Test func testDecodingBoolAsLogicalString() throws {
+  @Test
+  func `decoding bool as logical string`() throws {
     struct Response: Codable {
       @LosslessBoolValue var a: Bool
       @LosslessBoolValue var b: Bool

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueOmitNilTests.swift
@@ -18,7 +18,7 @@ struct OptionalLosslessValueOmitNilTests {
   }
 
   @Test
-  func encodingNilOmitsKey() throws {
+  func `encoding nil omits key`() throws {
     // given
     let fixture = Fixture(optionalString: nil, optionalInt: nil)
 
@@ -33,7 +33,7 @@ struct OptionalLosslessValueOmitNilTests {
   }
 
   @Test
-  func encodingPartialNilOmitsOnlyNilKeys() throws {
+  func `encoding partial nil omits only nil keys`() throws {
     // given
     let fixture = Fixture(optionalString: "hello", optionalInt: nil)
 
@@ -44,16 +44,16 @@ struct OptionalLosslessValueOmitNilTests {
 
     // then - only optionalInt (nil) is omitted
     let expectResult = #"""
-    {
-      "optionalString" : "hello"
-    }
-    """#
+      {
+        "optionalString" : "hello"
+      }
+      """#
     let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
   }
 
   @Test
-  func encodingDecodingNilRoundTrip() throws {
+  func `encoding decoding nil round trip`() throws {
     // given
     let fixture = Fixture(optionalString: nil, optionalInt: nil)
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueResilientTests.swift
@@ -18,8 +18,8 @@ struct OptionalLosslessValueResilientTests {
     @OptionalLosslessValue var optionalDoubleValue: Double?
   }
 
-  @Test("projected value provides error information for non-null values")
-  func projectedValueProvidesErrorInfoForNonNullValues() throws {
+  @Test
+  func `projected value provides error information for non-null values`() throws {
     // given
     let json = """
       {
@@ -51,8 +51,8 @@ struct OptionalLosslessValueResilientTests {
     #endif
   }
 
-  @Test("projected value provides info for null values")
-  func projectedValueProvidesInfoForNullValues() throws {
+  @Test
+  func `projected value provides info for null values`() throws {
     // given
     let json = """
       {
@@ -84,8 +84,8 @@ struct OptionalLosslessValueResilientTests {
     #endif
   }
 
-  @Test("projected value provides info for missing fields")
-  func projectedValueProvidesInfoForMissingFields() throws {
+  @Test
+  func `projected value provides info for missing fields`() throws {
     // given
     let json = """
       {}
@@ -113,7 +113,7 @@ struct OptionalLosslessValueResilientTests {
   }
 
   @Test
-  func invalidValue() throws {
+  func `invalid value`() throws {
     // given
     struct MixedFixture: Decodable {
       @OptionalLosslessValue var optionalStringValue: String?
@@ -140,7 +140,6 @@ struct OptionalLosslessValueResilientTests {
   }
 
   @Test(
-    "handles type conversion with bool strategy",
     arguments: [
       (#"{ "value": "true" }"#, true as Bool?, ResilientDecodingOutcome.decodedSuccessfully),
       (#"{ "value": "yes" }"#, true as Bool?, .decodedSuccessfully),
@@ -150,10 +149,10 @@ struct OptionalLosslessValueResilientTests {
       (#"{}"#, nil as Bool?, .keyNotFound),
     ]
   )
-  func handlesTypeConversionWithBoolStrategy(
+  func `handles type conversion with bool strategy`(
     json: String,
     expected: Bool?,
-    outcome: ResilientDecodingOutcome
+    outcome: ResilientDecodingOutcome,
   ) throws {
     // given
     struct BoolFixture: Decodable {

--- a/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LosslessValue/OptionalLosslessValueTests.swift
@@ -18,16 +18,16 @@ struct OptionalLosslessValueTests {
   }
 
   @Test
-  func decodingNullValues() throws {
+  func `decoding null values`() throws {
     // given
     let json = #"""
-    {
-      "optionalBool": null,
-      "optionalString": null,
-      "optionalInt": null,
-      "optionalDouble": null
-    }
-    """#
+      {
+        "optionalBool": null,
+        "optionalString": null,
+        "optionalInt": null,
+        "optionalDouble": null
+      }
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))
@@ -41,11 +41,11 @@ struct OptionalLosslessValueTests {
   }
 
   @Test
-  func decodingMissingFields() throws {
+  func `decoding missing fields`() throws {
     // given
     let json = #"""
-    {}
-    """#
+      {}
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))
@@ -59,16 +59,16 @@ struct OptionalLosslessValueTests {
   }
 
   @Test
-  func decodingMisalignedTypesFromJSON() throws {
+  func `decoding misaligned types from JSON`() throws {
     // given
     let json = #"""
-    {
-      "optionalBool": "true",
-      "optionalString": 42,
-      "optionalInt": "1",
-      "optionalDouble": "7.1"
-    }
-    """#
+      {
+        "optionalBool": "true",
+        "optionalString": 42,
+        "optionalInt": "1",
+        "optionalDouble": "7.1"
+      }
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))
@@ -81,17 +81,17 @@ struct OptionalLosslessValueTests {
     #expect(fixture.optionalDouble == 7.1)
   }
 
-  @Test("decoding expected types")
-  func decodingExpectedTypes() throws {
+  @Test
+  func `decoding expected types`() throws {
     // given
     let json = #"""
-    {
-      "optionalBool": true,
-      "optionalString": "42",
-      "optionalInt": 7,
-      "optionalDouble": 7.1
-    }
-    """#
+      {
+        "optionalBool": true,
+        "optionalString": "42",
+        "optionalInt": 7,
+        "optionalDouble": 7.1
+      }
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))
@@ -104,14 +104,14 @@ struct OptionalLosslessValueTests {
     #expect(fixture.optionalDouble == 7.1)
   }
 
-  @Test("encoding and decoding with null values")
-  func encodingAndDecodingWithNullValues() throws {
+  @Test
+  func `encoding and decoding with null values`() throws {
     // given
     let fixture = Fixture(
       optionalBool: nil,
       optionalString: nil,
       optionalInt: nil,
-      optionalDouble: nil
+      optionalDouble: nil,
     )
 
     // when
@@ -122,14 +122,14 @@ struct OptionalLosslessValueTests {
     #expect(fixture == decodedFixture)
   }
 
-  @Test("encoding and decoding with mixed values")
-  func encodingAndDecodingWithMixedValues() throws {
+  @Test
+  func `encoding and decoding with mixed values`() throws {
     // given
     let fixture = Fixture(
       optionalBool: true,
       optionalString: nil,
       optionalInt: 42,
-      optionalDouble: nil
+      optionalDouble: nil,
     )
 
     // when
@@ -140,17 +140,17 @@ struct OptionalLosslessValueTests {
     #expect(fixture == decodedFixture)
   }
 
-  @Test("decoding with partial null values")
-  func decodingWithPartialNullValues() throws {
+  @Test
+  func `decoding with partial null values`() throws {
     // given
     let json = #"""
-    {
-      "optionalBool": true,
-      "optionalString": null,
-      "optionalInt": "42",
-      "optionalDouble": 3.14
-    }
-    """#
+      {
+        "optionalBool": true,
+        "optionalString": null,
+        "optionalInt": "42",
+        "optionalDouble": 3.14
+      }
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))
@@ -164,7 +164,6 @@ struct OptionalLosslessValueTests {
   }
 
   @Test(
-    "decoding boolean from various string values",
     arguments: [
       (#"{ "value": "true" }"#, true as Bool?),
       (#"{ "value": "yes" }"#, true as Bool?),
@@ -176,7 +175,7 @@ struct OptionalLosslessValueTests {
       (#"{ "value": null }"#, nil as Bool?),
     ]
   )
-  func decodingBooleanFromVariousStringValues(json: String, expected: Bool?) throws {
+  func `decoding boolean from various string values`(json: String, expected: Bool?) throws {
     // given
     struct BoolFixture: Codable {
       @OptionalLosslessValueCodable<LosslessBooleanStrategy<Bool>> var value: Bool?
@@ -190,17 +189,17 @@ struct OptionalLosslessValueTests {
     #expect(fixture.value == expected)
   }
 
-  @Test("decoding encoded misaligned types with nulls")
-  func decodingEncodedMisalignedTypesWithNulls() throws {
+  @Test
+  func `decoding encoded misaligned types with nulls`() throws {
     // given
     let json = #"""
-    {
-      "optionalBool": "true",
-      "optionalString": null,
-      "optionalInt": "7",
-      "optionalDouble": null
-    }
-    """#
+      {
+        "optionalBool": "true",
+        "optionalString": null,
+        "optionalInt": "7",
+        "optionalDouble": null
+      }
+      """#
 
     // when
     let jsonData = try #require(json.data(using: .utf8))

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayResilientTests.swift
@@ -22,8 +22,8 @@ struct LossyArrayResilientTests {
     @LossyArray var objects: [NestedObject]
   }
 
-  @Test("projected value provides error information in DEBUG")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information in DEBUG`() throws {
     let json = """
       {
         "integers": [1, "invalid", 3, null, 5],
@@ -71,8 +71,8 @@ struct LossyArrayResilientTests {
     #endif
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() throws {
+  @Test
+  func `error reporting with JSONDecoder`() throws {
     let json = """
       {
         "integers": [1, "two", 3],
@@ -98,8 +98,8 @@ struct LossyArrayResilientTests {
     #endif
   }
 
-  @Test("decode with reportResilientDecodingErrors")
-  func decodeWithReportFlag() throws {
+  @Test
+  func `decode with reportResilientDecodingErrors`() throws {
     let json = """
       {
         "integers": [1, "invalid", 3],
@@ -114,7 +114,7 @@ struct LossyArrayResilientTests {
     let (fixture, errorDigest) = try decoder.decode(
       Fixture.self,
       from: data,
-      reportResilientDecodingErrors: true
+      reportResilientDecodingErrors: true,
     )
 
     #expect(fixture.integers == [1, 3])
@@ -127,8 +127,8 @@ struct LossyArrayResilientTests {
     #endif
   }
 
-  @Test("empty array on complete failure")
-  func emptyArrayOnCompleteFailure() throws {
+  @Test
+  func `empty array on complete failure`() throws {
     let json = """
       {
         "integers": "not an array",

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyArrayTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -21,7 +21,8 @@ struct LossyArrayTests {
     @LossyArray var nonPrimitiveValues: [NestedFixture]
   }
 
-  @Test func testDecodingLossyArrayIgnoresFailableElements() throws {
+  @Test
+  func `decoding lossy array ignores failable elements`() throws {
     // given
     let jsonData = #"{ "values": [1, null, 3, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
 
@@ -33,7 +34,8 @@ struct LossyArrayTests {
     #expect(fixture.nonPrimitiveValues == [])
   }
 
-  @Test func testDecodingLossyArrayIgnoresLossyElements() throws {
+  @Test
+  func `decoding lossy array ignores lossy elements`() throws {
     // given
     let jsonData = #"{ "values": [1, null, "3", false, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
 
@@ -45,7 +47,8 @@ struct LossyArrayTests {
     #expect(fixture.nonPrimitiveValues == [])
   }
 
-  @Test func testEncodingDecodedLossyArrayIgnoresFailableElements() throws {
+  @Test
+  func `encoding decoded lossy array ignores failable elements`() throws {
     // given
     let jsonData = #"{ "values": [null, 2, null, 4], "nonPrimitiveValues": [null] }"#.data(using: .utf8)!
     var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -61,7 +64,8 @@ struct LossyArrayTests {
     #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "1", two: ["x": ["y"]])])
   }
 
-  @Test func testEncodingDecodedLossyArrayRetainsContents() throws {
+  @Test
+  func `encoding decoded lossy array retains contents`() throws {
     // given
     let jsonData = #"{ "values": [1, 2], "nonPrimitiveValues": [{ "one": "one", "two": {"key": ["value"]}}] }"#
       .data(using: .utf8)!
@@ -76,7 +80,8 @@ struct LossyArrayTests {
     #expect(fixture.nonPrimitiveValues == [Fixture.NestedFixture(one: "one", two: ["key": ["value"]])])
   }
 
-  @Test func testEncodingDecodingLossyArrayWorksWithCustomStrategies() throws {
+  @Test
+  func `encoding decoding lossy array works with custom strategies`() throws {
     // given
     struct Fixture: Equatable, Codable {
       @LossyArray var theValues: [Date]

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryResilientTests.swift
@@ -23,8 +23,8 @@ struct LossyDictionaryResilientTests {
     @LossyDictionary var objectDict: [String: NestedObject]
   }
 
-  @Test("projected value provides error information for each failed key-value pair")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information for each failed key-value pair`() throws {
     let json = """
       {
         "stringDict": {
@@ -78,8 +78,8 @@ struct LossyDictionaryResilientTests {
     #endif
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() throws {
+  @Test
+  func `error reporting with JSONDecoder`() throws {
     let json = """
       {
         "stringDict": {
@@ -109,8 +109,8 @@ struct LossyDictionaryResilientTests {
     #endif
   }
 
-  @Test("complete failure results in empty dictionary")
-  func completeFailure() throws {
+  @Test
+  func `complete failure results in empty dictionary`() throws {
     let json = """
       {
         "stringDict": "not a dictionary",
@@ -136,8 +136,8 @@ struct LossyDictionaryResilientTests {
     #endif
   }
 
-  @Test("missing keys result in empty dictionary")
-  func missingKeys() throws {
+  @Test
+  func `missing keys result in empty dictionary`() throws {
     let json = "{}"
 
     let decoder = JSONDecoder()

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyDictionaryTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -16,7 +16,8 @@ struct LossyDictionaryTests {
     @LossyDictionary var intToString: [Int: String]
   }
 
-  @Test func testDecodingLossyDictionaryIgnoresFailableElements() throws {
+  @Test
+  func `decoding lossy dictionary ignores failable elements`() throws {
     // given
     let jsonData = """
       {
@@ -41,7 +42,8 @@ struct LossyDictionaryTests {
     #expect(fixture.intToString == [1: "one", 2: "two"])
   }
 
-  @Test func testEncodingDecodedLossyDictionaryIgnoresFailableElements() throws {
+  @Test
+  func `encoding decoded lossy dictionary ignores failable elements`() throws {
     // given
     let jsonData = """
       {
@@ -70,7 +72,8 @@ struct LossyDictionaryTests {
     #expect(fixture.intToString == [1: "one", 2: "two", 3: "three"])
   }
 
-  @Test func testEncodingDecodedLosslessArrayRetainsContents() throws {
+  @Test
+  func `encoding decoded lossless array retains contents`() throws {
     // given
     let jsonData = """
       {
@@ -95,7 +98,8 @@ struct LossyDictionaryTests {
     #expect(fixture.intToString == [1: "one", 2: "two", 3: "three"])
   }
 
-  @Test func testEncodingLosslessDictionaryRetainsKeys() throws {
+  @Test
+  func `encoding lossless dictionary retains keys`() throws {
     // given
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -109,7 +113,7 @@ struct LossyDictionaryTests {
         "normal key": 4,
         "another_key": 5,
       ],
-      intToString: [:]
+      intToString: [:],
     )
 
     // when

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalOmitNilTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalOmitNilTests.swift
@@ -18,7 +18,7 @@ struct LossyOptionalOmitNilTests {
   }
 
   @Test
-  func encodingNilOmitsKey() throws {
+  func `encoding nil omits key`() throws {
     // given
     let fixture = Fixture(url: nil, name: nil)
 
@@ -33,7 +33,7 @@ struct LossyOptionalOmitNilTests {
   }
 
   @Test
-  func encodingPartialNilOmitsOnlyNilKeys() throws {
+  func `encoding partial nil omits only nil keys`() throws {
     // given
     let fixture = Fixture(url: nil, name: "hello")
 
@@ -44,16 +44,16 @@ struct LossyOptionalOmitNilTests {
 
     // then - only url (nil) is omitted
     let expectResult = #"""
-    {
-      "name" : "hello"
-    }
-    """#
+      {
+        "name" : "hello"
+      }
+      """#
     let json = try #require(String(bytes: data, encoding: .utf8))
     #expect(json == expectResult)
   }
 
   @Test
-  func encodingDecodingNilRoundTrip() throws {
+  func `encoding decoding nil round trip`() throws {
     // given
     let fixture = Fixture(url: nil, name: nil)
 

--- a/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/LossyValue/LossyOptionalTests.swift
@@ -5,8 +5,8 @@
 //  Created by Elon on 2023/04/25.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -14,7 +14,8 @@ struct DefaultNilTests {
   /// This test demonstrates the problem that `@LossyOptional` solves. When decoding
   /// optional types, it often the case that we end up with an error instead of
   /// defaulting back to `nil`.
-  @Test func testDecodingBadUrlAsOptionalWithoutDefaultNil() {
+  @Test
+  func `decoding bad url as optional without default nil`() {
     // given
     struct Fixture: Codable {
       var a: URL?
@@ -25,7 +26,8 @@ struct DefaultNilTests {
     #expect(throws: (any Error).self) { try JSONDecoder().decode(Fixture.self, from: jsonData) }
   }
 
-  @Test func testDecodingWithUrlConversions() throws {
+  @Test
+  func `decoding with url conversions`() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: URL?
@@ -43,7 +45,8 @@ struct DefaultNilTests {
     #expect(fixture.b == URL(string: goodUrlString))
   }
 
-  @Test func testDecodingWithIntegerConversions() throws {
+  @Test
+  func `decoding with integer conversions`() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: Int?
@@ -61,7 +64,8 @@ struct DefaultNilTests {
     #expect(fixture.b == 3)
   }
 
-  @Test func testDecodingWithNullValue() throws {
+  @Test
+  func `decoding with null value`() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: String?
@@ -75,7 +79,8 @@ struct DefaultNilTests {
     #expect(fixture.a == nil)
   }
 
-  @Test func testDecodingWithMissingKey() throws {
+  @Test
+  func `decoding with missing key`() throws {
     // given
     struct Fixture: Codable {
       @LossyOptional var a: String?

--- a/Tests/KarrotCodableKitTests/BetterCodable/RawRepresentableTests.swift
+++ b/Tests/KarrotCodableKitTests/BetterCodable/RawRepresentableTests.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2023 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 @testable import KarrotCodableKit
 
 struct RawRepresentableTests {
 
-  @Test func testEnumDecodingWithDefaultValue() throws {
+  @Test
+  func `enum decoding with default value`() throws {
     // given
     enum VehicleType: String, Codable, DefaultCodableStrategy {
       case car

--- a/Tests/KarrotCodableKitTests/Encodable+ToDictionaryTests.swift
+++ b/Tests/KarrotCodableKitTests/Encodable+ToDictionaryTests.swift
@@ -6,19 +6,20 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct Encodable_ToDictionaryTests {
 
-  @Test func test_toDictionary() throws {
+  @Test
+  func `to dictionary`() throws {
     // given
     let dummy = ObjectDummy(
       id: 1,
       name: "ray",
-      wallet: ObjectDummy.Wallet(money: 1000)
+      wallet: ObjectDummy.Wallet(money: 1000),
     )
 
     // when
@@ -32,7 +33,8 @@ struct Encodable_ToDictionaryTests {
     #expect(wallet?["money"] as? Int == 1000)
   }
 
-  @Test func test_asDictionary_optional() throws {
+  @Test
+  func `as dictionary optional`() throws {
     // given
     let dummy = OptionalDummy(value: nil)
 

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueResilientTests.swift
@@ -8,8 +8,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     @DummyNotice.DefaultEmptyPolymorphicArray var notices: [any DummyNotice]
   }
 
-  @Test("Empty array decoding should have decodedSuccessfully outcome")
-  func emptyArray() throws {
+  @Test
+  func `Empty array decoding should have decodedSuccessfully outcome`() throws {
     // given
     let json = """
       {
@@ -29,8 +29,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Successful array decoding should have decodedSuccessfully outcome")
-  func successfulArrayDecoding() throws {
+  @Test
+  func `Successful array decoding should have decodedSuccessfully outcome`() throws {
     // given
     let json = """
       {
@@ -66,8 +66,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array when array contains any invalid element")
-  func arrayWithAnyInvalidElement() throws {
+  @Test
+  func `Should return empty array when array contains any invalid element`() throws {
     // given
     let json = """
       {
@@ -102,8 +102,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array when key is missing")
-  func missingKey() throws {
+  @Test
+  func `Should return empty array when key is missing`() throws {
     // given
     let json = """
       {}
@@ -121,8 +121,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array for null value")
-  func nullValue() throws {
+  @Test
+  func `Should return empty array for null value`() throws {
     // given
     let json = """
       {
@@ -142,8 +142,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array for invalid type")
-  func invalidType() throws {
+  @Test
+  func `Should return empty array for invalid type`() throws {
     // given
     let json = """
       {
@@ -167,8 +167,8 @@ struct DefaultEmptyPolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Error reporter should be called")
-  func errorReporting() throws {
+  @Test
+  func `Error reporter should be called`() throws {
     /// given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/DefaultEmptyPolymorphicArrayValueTests.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct DefaultEmptyPolymorphicArrayValueTests {
 
-  @Test func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `encoding default empty polymorphic array value`() throws {
     // given
     let response = OptionalArrayDummyResponse(
       notices1: [
@@ -21,26 +22,26 @@ struct DefaultEmptyPolymorphicArrayValueTests {
           type: .callout,
           title: nil,
           description: "test",
-          icon: "test_icon"
-        ),
+          icon: "test_icon",
+        )
       ],
-      notices2: []
+      notices2: [],
     )
 
     let expectResult = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ],
-      "notices2" : [
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ],
+        "notices2" : [
 
-      ]
-    }
-    """#
+        ]
+      }
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -52,19 +53,20 @@ struct DefaultEmptyPolymorphicArrayValueTests {
     #expect(jsonString == expectResult)
   }
 
-  @Test func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding default empty polymorphic array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -75,14 +77,15 @@ struct DefaultEmptyPolymorphicArrayValueTests {
     #expect(result.notices2.isEmpty)
   }
 
-  @Test func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding encoding default empty polymorphic array value`() throws {
     // given
     let json = #"""
-    {
-      "notices1" : null,
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : null,
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(json.utf8))
@@ -98,38 +101,39 @@ struct DefaultEmptyPolymorphicArrayValueTests {
 
     // then
     let expectResult = #"""
-    {
-      "notices1" : [
+      {
+        "notices1" : [
 
-      ],
-      "notices2" : [
+        ],
+        "notices2" : [
 
-      ]
-    }
-    """#
+        ]
+      }
+      """#
     let jsonString = String(decoding: data, as: UTF8.self)
     #expect(jsonString == expectResult)
   }
 }
 
 extension DefaultEmptyPolymorphicArrayValueTests {
-  @Test func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding fail element in default empty polymorphic array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -140,25 +144,26 @@ extension DefaultEmptyPolymorphicArrayValueTests {
 }
 
 extension DefaultEmptyPolymorphicArrayValueTests {
-  @Test func testDecodingOnlyValue() throws {
+  @Test
+  func `decoding only value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices2" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ],
-      "notice3" : null
-    }
-    """#
+      {
+        "notices2" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ],
+        "notice3" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalAarrayDummyDecodableResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/LossyArrayDecodeIfPresentTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/LossyArrayDecodeIfPresentTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2026 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -17,32 +17,34 @@ import KarrotCodableKit
 /// compiler-generated code always calls `decode`).
 struct LossyArrayDecodeIfPresentTests {
 
-  @Test func testDecodeIfPresentReturnsNilForMissingKey() throws {
+  @Test
+  func `decode if present returns nil for missing key`() throws {
     // given
     let jsonData = #"{ }"#
 
     // when
     let result = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
     #expect(result.notices1 == nil)
   }
 
-  @Test func testDecodeIfPresentReturnsEmptyArrayForNullValue() throws {
+  @Test
+  func `decode if present returns empty array for null value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : null
-    }
-    """#
+      {
+        "notices1" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -50,24 +52,25 @@ struct LossyArrayDecodeIfPresentTests {
     #expect(notices1.wrappedValue.isEmpty)
   }
 
-  @Test func testDecodeIfPresentDecodesPresentArray() throws {
+  @Test
+  func `decode if present decodes present array`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -76,18 +79,19 @@ struct LossyArrayDecodeIfPresentTests {
     #expect(notices1.wrappedValue.first?.type == .callout)
   }
 
-  @Test func testDecodeIfPresentRecoversEmptyArrayForNonArrayValue() throws {
+  @Test
+  func `decode if present recovers empty array for non array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : "not an array"
-    }
-    """#
+      {
+        "notices1" : "not an array"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: matches `decode(_:forKey:)`, which recovers a non-array value to an empty array
@@ -96,22 +100,23 @@ struct LossyArrayDecodeIfPresentTests {
   }
 
   #if DEBUG
-  @Test func testDecodeIfPresentNonArrayOutcomeMatchesDecode() throws {
+  @Test
+  func `decode if present non array outcome matches decode`() throws {
     // given: the same non-array payload decoded through both container entry points
     let jsonData = #"""
-    {
-      "notices1" : "not an array"
-    }
-    """#
+      {
+        "notices1" : "not an array"
+      }
+      """#
 
     // when
     let decodeResult = try JSONDecoder().decode(
       OptionalLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
     let decodeIfPresentResult = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: both entry points recover and report the same outcome
@@ -120,22 +125,23 @@ struct LossyArrayDecodeIfPresentTests {
     #expect(notices1.outcome == decodeResult.$notices1.outcome)
   }
 
-  @Test func testDecodeIfPresentNullOutcomeMatchesDecode() throws {
+  @Test
+  func `decode if present null outcome matches decode`() throws {
     // given: the same null payload decoded through both container entry points
     let jsonData = #"""
-    {
-      "notices1" : null
-    }
-    """#
+      {
+        "notices1" : null
+      }
+      """#
 
     // when
     let decodeResult = try JSONDecoder().decode(
       OptionalLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
     let decodeIfPresentResult = try JSONDecoder().decode(
       LossyArrayDecodeIfPresentDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: a null value must not be reported as a clean success by either entry point
@@ -158,9 +164,9 @@ private struct LossyArrayDecodeIfPresentDummyResponse: Decodable {
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.notices1 = try container.decodeIfPresent(
+    notices1 = try container.decodeIfPresent(
       PolymorphicLossyArrayValue<DummyNoticeCodableStrategy>.self,
-      forKey: .notices1
+      forKey: .notices1,
     )
   }
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/LossyArrayRecoveryPolicyTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/LossyArrayRecoveryPolicyTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2026 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
@@ -22,18 +22,19 @@ struct LossyArrayRecoveryPolicyTests {
 
   // MARK: - Array-level recovery for a non-array value
 
-  @Test func testOptionalLossyArrayRecoversEmptyArrayForNonArrayValue() throws {
+  @Test
+  func `optional lossy array recovers empty array for non array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : "not an array"
-    }
-    """#
+      {
+        "notices1" : "not an array"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: recovers to an empty array; `nil` stays reserved for a missing key or explicit null
@@ -42,18 +43,19 @@ struct LossyArrayRecoveryPolicyTests {
   }
 
   #if DEBUG
-  @Test func testOptionalLossyArrayNonArrayValueOutcomeIsRecovered() throws {
+  @Test
+  func `optional lossy array non array value outcome is recovered`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : "not an array"
-    }
-    """#
+      {
+        "notices1" : "not an array"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: the recovery is visible in the outcome, matching PolymorphicLossyArrayValue
@@ -63,36 +65,38 @@ struct LossyArrayRecoveryPolicyTests {
 
   // MARK: - Direct decoding (bypasses the KeyedDecodingContainer overloads)
 
-  @Test func testLossyArrayRecoversWhenDecodedDirectly() throws {
+  @Test
+  func `lossy array recovers when decoded directly`() throws {
     // given: dictionary values invoke `init(from:)` directly, bypassing container overloads
     let jsonData = #"""
-    {
-      "group" : "not an array"
-    }
-    """#
+      {
+        "group" : "not an array"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       [String: PolymorphicLossyArrayValue<DummyNoticeCodableStrategy>].self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
     #expect(try #require(result["group"]).wrappedValue.isEmpty)
   }
 
-  @Test func testOptionalLossyArrayRecoversWhenDecodedDirectly() throws {
+  @Test
+  func `optional lossy array recovers when decoded directly`() throws {
     // given
     let jsonData = #"""
-    {
-      "group" : "not an array"
-    }
-    """#
+      {
+        "group" : "not an array"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       [String: OptionalPolymorphicLossyArrayValue<DummyNoticeCodableStrategy>].self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -102,28 +106,29 @@ struct LossyArrayRecoveryPolicyTests {
   // MARK: - Element failures are recorded in the outcome (as with @LossyArray)
 
   #if DEBUG
-  @Test func testLossyArrayElementFailureIsRecordedInOutcome() throws {
+  @Test
+  func `lossy array element failure is recorded in outcome`() throws {
     // given: one invalid element (missing required 'description') and one valid element
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then: valid elements are kept and the failure surfaces through the outcome
@@ -131,28 +136,29 @@ struct LossyArrayRecoveryPolicyTests {
     #expect(result.$notices1.error is ResilientDecodingOutcome.ArrayDecodingError<any DummyNotice>)
   }
 
-  @Test func testOptionalLossyArrayElementFailureIsRecordedInOutcome() throws {
+  @Test
+  func `optional lossy array element failure is recorded in outcome`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicArrayValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicArrayValueResilientTests.swift
@@ -8,8 +8,8 @@ struct PolymorphicArrayValueResilientTests {
     @DummyNotice.PolymorphicArray var notices: [any DummyNotice]
   }
 
-  @Test("Empty array decoding should have decodedSuccessfully outcome")
-  func emptyArray() throws {
+  @Test
+  func `Empty array decoding should have decodedSuccessfully outcome`() throws {
     // given
     let json = """
       {
@@ -29,8 +29,8 @@ struct PolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Successful array decoding should have decodedSuccessfully outcome")
-  func successfulArrayDecoding() throws {
+  @Test
+  func `Successful array decoding should have decodedSuccessfully outcome`() throws {
     // given
     let json = """
       {
@@ -73,8 +73,8 @@ struct PolymorphicArrayValueResilientTests {
     #endif
   }
 
-  @Test("Array should fail to decode if any element fails")
-  func arrayWithInvalidElement() throws {
+  @Test
+  func `Array should fail to decode if any element fails`() throws {
     // given
     let json = """
       {
@@ -99,8 +99,8 @@ struct PolymorphicArrayValueResilientTests {
     }
   }
 
-  @Test("Should throw error when key is missing")
-  func missingKey() throws {
+  @Test
+  func `Should throw error when key is missing`() throws {
     // given
     let json = """
       {}
@@ -113,8 +113,8 @@ struct PolymorphicArrayValueResilientTests {
     }
   }
 
-  @Test("Should throw error for invalid type")
-  func invalidType() throws {
+  @Test
+  func `Should throw error for invalid type`() throws {
     // given
     let json = """
       {
@@ -129,8 +129,8 @@ struct PolymorphicArrayValueResilientTests {
     }
   }
 
-  @Test("Array element errors should be reported")
-  func arrayElementErrorReported() throws {
+  @Test
+  func `Array element errors should be reported`() throws {
     /// given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueResilientTests.swift
@@ -8,14 +8,14 @@ struct PolymorphicLossyArrayValueResilientTests {
     @DummyNotice.PolymorphicLossyArray var notices: [any DummyNotice]
   }
 
-  @Test("Empty array decoding should have decodedSuccessfully outcome")
-  func emptyArray() throws {
+  @Test
+  func `Empty array decoding should have decodedSuccessfully outcome`() throws {
     // given
     let json = """
-    {
-      "notices": []
-    }
-    """
+      {
+        "notices": []
+      }
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))
@@ -30,27 +30,27 @@ struct PolymorphicLossyArrayValueResilientTests {
     #endif
   }
 
-  @Test("Successful array decoding should have all elements succeed")
-  func successfulArrayDecoding() throws {
+  @Test
+  func `Successful array decoding should have all elements succeed`() throws {
     // given
     let json = """
-    {
-      "notices": [
-        {
-          "type": "callout",
-          "title": "First",
-          "description": "First callout",
-          "icon": "icon1.png"
-        },
-        {
-          "type": "actionable-callout",
-          "title": "Second",
-          "description": "Second callout",
-          "action": "https://example.com"
-        }
-      ]
-    }
-    """
+      {
+        "notices": [
+          {
+            "type": "callout",
+            "title": "First",
+            "description": "First callout",
+            "icon": "icon1.png"
+          },
+          {
+            "type": "actionable-callout",
+            "title": "Second",
+            "description": "Second callout",
+            "action": "https://example.com"
+          }
+        ]
+      }
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))
@@ -69,33 +69,33 @@ struct PolymorphicLossyArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should decode only valid elements when array has invalid elements")
-  func arrayWithInvalidElements() throws {
+  @Test
+  func `Should decode only valid elements when array has invalid elements`() throws {
     // given
     let json = """
-    {
-      "notices": [
-        {
-          "type": "callout",
-          "title": "Valid",
-          "description": "Valid callout",
-          "icon": "icon.png"
-        },
-        {
-          "type": "invalid-type"
-        },
-        {
-          "type": "dismissible-callout",
-          "title": "Also Valid",
-          "description": "Another valid callout",
-          "key": "dismiss-key"
-        },
-        "not-an-object",
-        null,
-        123
-      ]
-    }
-    """
+      {
+        "notices": [
+          {
+            "type": "callout",
+            "title": "Valid",
+            "description": "Valid callout",
+            "icon": "icon.png"
+          },
+          {
+            "type": "invalid-type"
+          },
+          {
+            "type": "dismissible-callout",
+            "title": "Also Valid",
+            "description": "Another valid callout",
+            "key": "dismiss-key"
+          },
+          "not-an-object",
+          null,
+          123
+        ]
+      }
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))
@@ -121,12 +121,12 @@ struct PolymorphicLossyArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array when key is missing")
-  func missingKey() throws {
+  @Test
+  func `Should return empty array when key is missing`() throws {
     // given
     let json = """
-    {}
-    """
+      {}
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))
@@ -141,14 +141,14 @@ struct PolymorphicLossyArrayValueResilientTests {
     #endif
   }
 
-  @Test("Should return empty array for invalid type")
-  func invalidType() throws {
+  @Test
+  func `Should return empty array for invalid type`() throws {
     // given
     let json = """
-    {
-      "notices": "not an array"
-    }
-    """
+      {
+        "notices": "not an array"
+      }
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))
@@ -167,24 +167,24 @@ struct PolymorphicLossyArrayValueResilientTests {
     #endif
   }
 
-  @Test("Error reporter should be called partially")
-  func partialErrorReporting() throws {
+  @Test
+  func `Error reporter should be called partially`() throws {
     /// given
     let json = """
-    {
-      "notices": [
-        {
-          "type": "callout",
-          "title": "Valid",
-          "description": "Valid callout",
-          "icon": "icon.png"
-        },
-        {
-          "type": "invalid-type"
-        }
-      ]
-    }
-    """
+      {
+        "notices": [
+          {
+            "type": "callout",
+            "title": "Valid",
+            "description": "Valid callout",
+            "icon": "icon.png"
+          },
+          {
+            "type": "invalid-type"
+          }
+        ]
+      }
+      """
 
     // when
     let data = try #require(json.data(using: .utf8))

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/ArrayValue/PolymorphicLossyArrayValueTests.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct PolymorphicLossyArrayValueTests {
 
-  @Test func testEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `encoding default empty polymorphic array value`() throws {
     // given
     let response = OptionalLossyArrayDummyResponse(
       notices1: [
@@ -21,26 +22,26 @@ struct PolymorphicLossyArrayValueTests {
           type: .callout,
           title: nil,
           description: "test",
-          icon: "test_icon"
-        ),
+          icon: "test_icon",
+        )
       ],
-      notices2: []
+      notices2: [],
     )
 
     let expectResult = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ],
-      "notices2" : [
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ],
+        "notices2" : [
 
-      ]
-    }
-    """#
+        ]
+      }
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -52,19 +53,20 @@ struct PolymorphicLossyArrayValueTests {
     #expect(jsonString == expectResult)
   }
 
-  @Test func testDecodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding default empty polymorphic array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -75,14 +77,15 @@ struct PolymorphicLossyArrayValueTests {
     #expect(result.notices2.isEmpty)
   }
 
-  @Test func testDecodingEncodingDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding encoding default empty polymorphic array value`() throws {
     // given
     let json = #"""
-    {
-      "notices1" : null,
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : null,
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(json.utf8))
@@ -98,38 +101,39 @@ struct PolymorphicLossyArrayValueTests {
 
     // then
     let expectResult = #"""
-    {
-      "notices1" : [
+      {
+        "notices1" : [
 
-      ],
-      "notices2" : [
+        ],
+        "notices2" : [
 
-      ]
-    }
-    """#
+        ]
+      }
+      """#
     let jsonString = String(decoding: data, as: UTF8.self)
     #expect(jsonString == expectResult)
   }
 }
 
 extension PolymorphicLossyArrayValueTests {
-  @Test func testDecodingFailElementInDefaultEmptyPolymorphicArrayValue() throws {
+  @Test
+  func `decoding fail element in default empty polymorphic array value`() throws {
     // given: An array where one element (notice) is missing the required 'description' parameter.
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when: During decoding.
     let result = try JSONDecoder().decode(OptionalLossyArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -141,25 +145,26 @@ extension PolymorphicLossyArrayValueTests {
 }
 
 extension PolymorphicLossyArrayValueTests {
-  @Test func testDecodingOnlyValue() throws {
+  @Test
+  func `decoding only value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices2" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ],
-      "notice3" : null
-    }
-    """#
+      {
+        "notices2" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ],
+        "notice3" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalLossyAarrayDummyDecodableResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumCodableTests.swift
@@ -6,22 +6,23 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct PolymorphicEnumCodableTests {
 
-  @Test func testPolymorphicEnumValue() throws {
+  @Test
+  func `polymorphic enum value`() throws {
     // given
     let json = #"""
-    {
-      "description" : "test",
-      "icon" : "test_icon",
-      "type" : "callout"
-    }
-    """#
+      {
+        "description" : "test",
+        "icon" : "test_icon",
+        "type" : "callout"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(CalloutBadge.self, from: Data(json.utf8))
@@ -41,36 +42,37 @@ struct PolymorphicEnumCodableTests {
 
     // then
     let expectResult = #"""
-    {
-      "description" : "test",
-      "icon" : "test_icon",
-      "type" : "callout"
-    }
-    """#
-    let jsonString = String(decoding: data, as: UTF8.self)
-    #expect(jsonString == expectResult)
-  }
-
-  @Test func testPolymorphicEnumArrayValue() throws {
-    // given
-    let json = #"""
-    [
       {
         "description" : "test",
         "icon" : "test_icon",
         "type" : "callout"
-      },
-      {
-        "description" : "test",
-        "key" : "hi",
-        "type" : "dismissible-callout"
-      },
-      {
-        "description" : "test",
-        "type" : "unknown-callout-type"
       }
-    ]
-    """#
+      """#
+    let jsonString = String(decoding: data, as: UTF8.self)
+    #expect(jsonString == expectResult)
+  }
+
+  @Test
+  func `polymorphic enum array value`() throws {
+    // given
+    let json = #"""
+      [
+        {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        },
+        {
+          "description" : "test",
+          "key" : "hi",
+          "type" : "dismissible-callout"
+        },
+        {
+          "description" : "test",
+          "type" : "unknown-callout-type"
+        }
+      ]
+      """#
 
     // when
     let result = try JSONDecoder().decode([CalloutBadge].self, from: Data(json.utf8))
@@ -95,23 +97,23 @@ struct PolymorphicEnumCodableTests {
 
     // then
     let expectResult = #"""
-    [
-      {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      {
-        "description" : "test",
-        "key" : "hi",
-        "type" : "dismissible-callout"
-      },
-      {
-        "description" : "test",
-        "type" : "undefined-callout"
-      }
-    ]
-    """#
+      [
+        {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        },
+        {
+          "description" : "test",
+          "key" : "hi",
+          "type" : "dismissible-callout"
+        },
+        {
+          "description" : "test",
+          "type" : "undefined-callout"
+        }
+      ]
+      """#
     let jsonString = String(decoding: data, as: UTF8.self)
     #expect(jsonString == expectResult)
   }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Enum/PolymorphicEnumDecodableTests.swift
@@ -6,22 +6,23 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct PolymorphicEnumDecodableTests {
 
-  @Test func testPolymorphicEnumValue() throws {
+  @Test
+  func `polymorphic enum value`() throws {
     // given
     let json = #"""
-    {
-      "description" : "test",
-      "icon" : "test_icon",
-      "type" : "callout"
-    }
-    """#
+      {
+        "description" : "test",
+        "icon" : "test_icon",
+        "type" : "callout"
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DecodableCalloutBadge.self, from: Data(json.utf8))
@@ -35,26 +36,27 @@ struct PolymorphicEnumDecodableTests {
     }
   }
 
-  @Test func testPolymorphicEnumDecodableArrayValue() throws {
+  @Test
+  func `polymorphic enum decodable array value`() throws {
     // given
     let json = #"""
-    [
-      {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      {
-        "description" : "test",
-        "key" : "hi",
-        "type" : "dismissible-callout"
-      },
-      {
-        "description" : "test",
-        "type" : "unknown-callout-type"
-      }
-    ]
-    """#
+      [
+        {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        },
+        {
+          "description" : "test",
+          "key" : "hi",
+          "type" : "dismissible-callout"
+        },
+        {
+          "description" : "test",
+          "type" : "unknown-callout-type"
+        }
+      ]
+      """#
 
     // when
     let result = try JSONDecoder().decode([DecodableCalloutBadge].self, from: Data(json.utf8))

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueResilientTests.swift
@@ -32,29 +32,29 @@ struct OptionalPolymorphicArrayValueResilientTests {
   // MARK: - Successful Decoding Tests
 
   @Test
-  func decodesValidArrayWithoutErrors() throws {
+  func `decodes valid array without errors`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": [
-        {
-          "description": "test1",
-          "icon": "test_icon1",
-          "type": "callout"
-        },
-        {
-          "description": "test2",
-          "action": "https://example.com",
-          "type": "actionable-callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices": [
+          {
+            "description": "test1",
+            "icon": "test_icon1",
+            "type": "callout"
+          },
+          {
+            "description": "test2",
+            "action": "https://example.com",
+            "type": "actionable-callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -77,18 +77,18 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func decodesEmptyArrayWithoutErrors() throws {
+  func `decodes empty array without errors`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": []
-    }
-    """#
+      {
+        "notices": []
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -101,18 +101,18 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func decodesNullValueWithoutErrors() throws {
+  func `decodes null value without errors`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": null
-    }
-    """#
+      {
+        "notices": null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -124,17 +124,17 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func decodesMissingKeyWithoutErrors() throws {
+  func `decodes missing key without errors`() throws {
     // given
     let jsonData = #"""
-    {
-    }
-    """#
+      {
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -148,21 +148,21 @@ struct OptionalPolymorphicArrayValueResilientTests {
   // MARK: - Error Reporting Tests
 
   @Test
-  func reportsErrorWhenInvalidElementInArray() throws {
+  func `reports error when invalid element in array`() throws {
     /// given - Missing required 'description' field in second element
     let jsonData = #"""
-    {
-      "notices": [
-        {
-          "description": "test1",
-          "type": "callout"
-        },
-        {
-          "type": "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices": [
+          {
+            "description": "test1",
+            "type": "callout"
+          },
+          {
+            "type": "callout"
+          }
+        ]
+      }
+      """#
 
     let decoder = JSONDecoder()
     let errorReporter = decoder.enableResilientDecodingErrorReporting()
@@ -183,13 +183,13 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func reportsErrorWhenNotArrayType() throws {
+  func `reports error when not array type`() throws {
     /// given
     let jsonData = #"""
-    {
-      "notices": "not an array"
-    }
-    """#
+      {
+        "notices": "not an array"
+      }
+      """#
 
     let decoder = JSONDecoder()
     let errorReporter = decoder.enableResilientDecodingErrorReporting()
@@ -213,23 +213,23 @@ struct OptionalPolymorphicArrayValueResilientTests {
 
   #if DEBUG
   @Test
-  func projectedValueReturnsNilErrorForSuccessfulDecoding() throws {
+  func `projected value returns nil error for successful decoding`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": [
-        {
-          "description": "test",
-          "type": "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices": [
+          {
+            "description": "test",
+            "type": "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -238,18 +238,18 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func projectedValueReturnsOutcomeForNilValue() throws {
+  func `projected value returns outcome for nil value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": null
-    }
-    """#
+      {
+        "notices": null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -258,17 +258,17 @@ struct OptionalPolymorphicArrayValueResilientTests {
   }
 
   @Test
-  func projectedValueReturnsOutcomeForMissingKey() throws {
+  func `projected value returns outcome for missing key`() throws {
     // given
     let jsonData = #"""
-    {
-    }
-    """#
+      {
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -280,25 +280,25 @@ struct OptionalPolymorphicArrayValueResilientTests {
   // MARK: - Multiple Properties Test
 
   @Test
-  func decodesMultiplePropertiesCorrectly() throws {
+  func `decodes multiple properties correctly`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices": [
-        {
-          "description": "test1",
-          "type": "callout"
-        }
-      ],
-      "notices2": null,
-      "notices3": []
-    }
-    """#
+      {
+        "notices": [
+          {
+            "description": "test1",
+            "type": "callout"
+          }
+        ],
+        "notices2": null,
+        "notices3": []
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       ResilientOptionalPolymorphicArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicArrayValueTests.swift
@@ -13,25 +13,25 @@ import KarrotCodableKit
 struct OptionalPolymorphicArrayValueTests {
 
   @Test
-  func decodingOptionalPolymorphicArrayValue() throws {
+  func `decoding optional polymorphic array value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test1",
-          "icon" : "test_icon1",
-          "type" : "callout"
-        },
-        {
-          "description" : "test2",
-          "action" : "https://example.com",
-          "type" : "actionable-callout"
-        }
-      ],
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test1",
+            "icon" : "test_icon1",
+            "type" : "callout"
+          },
+          {
+            "description" : "test2",
+            "action" : "https://example.com",
+            "type" : "actionable-callout"
+          }
+        ],
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalPolymorphicArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -54,7 +54,7 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func encodingOptionalPolymorphicArrayValue() throws {
+  func `encoding optional polymorphic array value`() throws {
     // given
     let response = OptionalPolymorphicArrayDummyResponse(
       notices1: [
@@ -62,23 +62,23 @@ struct OptionalPolymorphicArrayValueTests {
           type: .callout,
           title: nil,
           description: "test",
-          icon: "test_icon"
+          icon: "test_icon",
         )
       ],
-      notices2: nil
+      notices2: nil,
     )
 
     let expectResult = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -91,14 +91,14 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func decodingOptionalPolymorphicArrayValueWithEmptyArray() throws {
+  func `decoding optional polymorphic array value with empty array`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [],
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : [],
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalPolymorphicArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -110,19 +110,19 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func decodingOptionalPolymorphicArrayValueWithMissingKey() throws {
+  func `decoding optional polymorphic array value with missing key`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices2" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices2" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalPolymorphicArrayDummyResponse.self, from: Data(jsonData.utf8))
@@ -137,23 +137,23 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func decodingOptionalPolymorphicArrayValueWithInvalidElement() throws {
+  func `decoding optional polymorphic array value with invalid element`() throws {
     // given - Array with one invalid element (missing required 'description' property)
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when & then - Should throw error, not return nil or empty array
     #expect(throws: DecodingError.self) {
@@ -162,17 +162,17 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func decodingOptionalPolymorphicArrayValueWhenNotArray() throws {
+  func `decoding optional polymorphic array value when not array`() throws {
     // given - Value is not an array
     let jsonData = #"""
-    {
-      "notices1" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
+      {
+        "notices1" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        }
       }
-    }
-    """#
+      """#
 
     // when & then - Should throw error
     #expect(throws: DecodingError.self) {
@@ -181,11 +181,11 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func encodingDecodingNilValues() throws {
+  func `encoding decoding nil values`() throws {
     // given
     let response = OptionalPolymorphicArrayDummyResponse(
       notices1: nil,
-      notices2: nil
+      notices2: nil,
     )
 
     // when - encode
@@ -207,7 +207,7 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func encodingEmptyArrayIsKeptNotOmitted() throws {
+  func `encoding empty array is kept not omitted`() throws {
     // given - an empty array ([]) is non-nil and must be kept, not omitted like nil
     let response = OptionalPolymorphicArrayDummyResponse(notices1: [], notices2: nil)
 
@@ -227,7 +227,7 @@ struct OptionalPolymorphicArrayValueTests {
   }
 
   @Test
-  func encodingNilInUnkeyedContextProducesNull() throws {
+  func `encoding nil in unkeyed context produces null`() throws {
     // given - in an unkeyed container (array element) there is no key to omit,
     // so a nil wrapper is encoded as an explicit null (matching Apple's `[T?]` behavior)
     let elements: [DummyNotice.OptionalPolymorphicArray] = [

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicLossyArrayValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalPolymorphicLossyArrayValueTests.swift
@@ -14,30 +14,30 @@ import KarrotCodableKit
 struct OptionalPolymorphicLossyArrayValueTests {
 
   @Test
-  func decodingValidArray() throws {
+  func `decoding valid array`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test1",
-          "icon" : "test_icon1",
-          "type" : "callout"
-        },
-        {
-          "description" : "test2",
-          "action" : "https://example.com",
-          "type" : "actionable-callout"
-        }
-      ],
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test1",
+            "icon" : "test_icon1",
+            "type" : "callout"
+          },
+          {
+            "description" : "test2",
+            "action" : "https://example.com",
+            "type" : "actionable-callout"
+          }
+        ],
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -55,19 +55,19 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func decodingNullValue() throws {
+  func `decoding null value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : null,
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : null,
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -76,24 +76,24 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func decodingMissingKey() throws {
+  func `decoding missing key`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices2" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices2" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -104,19 +104,19 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func decodingEmptyArray() throws {
+  func `decoding empty array`() throws {
     // given
     let jsonData = #"""
-    {
-      "notices1" : [],
-      "notices2" : null
-    }
-    """#
+      {
+        "notices1" : [],
+        "notices2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then
@@ -126,28 +126,28 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func decodingWithInvalidElementSkipsIt() throws {
+  func `decoding with invalid element skips it`() throws {
     // given - Array with one invalid element (missing required 'description' property)
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon",
-          "type" : "callout"
-        },
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon",
+            "type" : "callout"
+          },
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then - Invalid element is skipped, valid element is kept
@@ -159,26 +159,26 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func decodingWithAllInvalidElementsReturnsEmptyArray() throws {
+  func `decoding with all invalid elements returns empty array`() throws {
     // given - Array where all elements are invalid
     let jsonData = #"""
-    {
-      "notices1" : [
-        {
-          "icon" : "test_icon1",
-          "type" : "callout"
-        },
-        {
-          "type" : "actionable-callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "icon" : "test_icon1",
+            "type" : "callout"
+          },
+          {
+            "type" : "actionable-callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then - All elements are invalid, so the array is empty (not nil)
@@ -195,23 +195,23 @@ struct OptionalPolymorphicLossyArrayValueTests {
           type: .callout,
           title: nil,
           description: "test",
-          icon: "test_icon"
+          icon: "test_icon",
         )
       ],
-      notices2: nil
+      notices2: nil,
     )
 
     let expectResult = #"""
-    {
-      "notices1" : [
-        {
-          "description" : "test",
-          "icon" : "test_icon",
-          "type" : "callout"
-        }
-      ]
-    }
-    """#
+      {
+        "notices1" : [
+          {
+            "description" : "test",
+            "icon" : "test_icon",
+            "type" : "callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -224,11 +224,11 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func encodingDecodingRoundTrip() throws {
+  func `encoding decoding round trip`() throws {
     // given
     let response = OptionalPolymorphicLossyArrayDummyResponse(
       notices1: nil,
-      notices2: nil
+      notices2: nil,
     )
 
     // when - encode
@@ -243,7 +243,7 @@ struct OptionalPolymorphicLossyArrayValueTests {
     // when - decode back
     let decodedResponse = try JSONDecoder().decode(
       OptionalPolymorphicLossyArrayDummyResponse.self,
-      from: data
+      from: data,
     )
 
     // then
@@ -252,7 +252,7 @@ struct OptionalPolymorphicLossyArrayValueTests {
   }
 
   @Test
-  func encodingEmptyArrayIsKeptNotOmitted() throws {
+  func `encoding empty array is kept not omitted`() throws {
     // given - an empty array ([]) is non-nil and must be kept, not omitted like nil
     let response = OptionalPolymorphicLossyArrayDummyResponse(notices1: [], notices2: nil)
 

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueResilientTests.swift
@@ -8,8 +8,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     @DummyNotice.LossyOptionalPolymorphic var notice: (any DummyNotice)?
   }
 
-  @Test("Outcome should be valueWasNil when decoding nil value")
-  func nilValue() throws {
+  @Test
+  func `Outcome should be valueWasNil when decoding nil value`() throws {
     // given
     let json = """
       {
@@ -29,8 +29,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Outcome should be keyNotFound when key is missing")
-  func missingKey() throws {
+  @Test
+  func `Outcome should be keyNotFound when key is missing`() throws {
     // given
     let json = """
       {}
@@ -48,8 +48,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Outcome should be decodedSuccessfully for successful decoding")
-  func successfulDecoding() throws {
+  @Test
+  func `Outcome should be decodedSuccessfully for successful decoding`() throws {
     // given
     let json = """
       {
@@ -79,8 +79,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Should return nil and record error for unknown type")
-  func unknownTypeReturnsNil() throws {
+  @Test
+  func `Should return nil and record error for unknown type`() throws {
     // given
     let json = """
       {
@@ -107,8 +107,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Should return nil and record error for invalid JSON format")
-  func invalidJSONReturnsNil() throws {
+  @Test
+  func `Should return nil and record error for invalid JSON format`() throws {
     // given
     let json = """
       {
@@ -133,8 +133,8 @@ struct LossyOptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Error reporter should be called")
-  func errorReporterCalled() throws {
+  @Test
+  func `Error reporter should be called`() throws {
     /// given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/LossyOptionalPolymorphicValueTests.swift
@@ -6,33 +6,34 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct LossyOptionalPolymorphicValueTests {
 
-  @Test func testEncodingLossyOptionalPolymorphicValue() throws {
+  @Test
+  func `encoding lossy optional polymorphic value`() throws {
     // given
     let response = LossyOptionalDummyResponse(
       notice1: DummyCallout(
         type: .callout,
         title: nil,
         description: "test",
-        icon: "test_icon"
+        icon: "test_icon",
       )
     )
 
     let expectResult = #"""
-    {
-      "notice1" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
+      {
+        "notice1" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        }
       }
-    }
-    """#
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -44,17 +45,18 @@ struct LossyOptionalPolymorphicValueTests {
     #expect(jsonString == expectResult)
   }
 
-  @Test func testDecodingLossyOptionalPolymorphicValue() throws {
+  @Test
+  func `decoding lossy optional polymorphic value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice2" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
+      {
+        "notice2" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        }
       }
-    }
-    """#
+      """#
 
     // when
     let result = try JSONDecoder().decode(LossyOptionalDummyResponse.self, from: Data(jsonData.utf8))
@@ -64,14 +66,15 @@ struct LossyOptionalPolymorphicValueTests {
     #expect(result.notice2?.type == .callout)
   }
 
-  @Test func testDecodingEncodingLossyOptionalPolymorphicValue() throws {
+  @Test
+  func `decoding encoding lossy optional polymorphic value`() throws {
     // given
     let json = #"""
-    {
-      "notice1" : null,
-      "notice2" : null
-    }
-    """#
+      {
+        "notice1" : null,
+        "notice2" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(LossyOptionalDummyResponse.self, from: Data(json.utf8))
@@ -93,23 +96,24 @@ struct LossyOptionalPolymorphicValueTests {
 }
 
 extension LossyOptionalPolymorphicValueTests {
-  @Test func testDecodingOnlyValue() throws {
+  @Test
+  func `decoding only value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice2" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      "notice3" : null
-    }
-    """#
+      {
+        "notice2" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        },
+        "notice3" : null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(
       OptionalDummyDecodableResponse.self,
-      from: Data(jsonData.utf8)
+      from: Data(jsonData.utf8),
     )
 
     // then

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueResilientTests.swift
@@ -8,8 +8,8 @@ struct OptionalPolymorphicValueResilientTests {
     @DummyNotice.OptionalPolymorphic var notice: (any DummyNotice)?
   }
 
-  @Test("Outcome should be valueWasNil when decoding nil value")
-  func nilValue() throws {
+  @Test
+  func `Outcome should be valueWasNil when decoding nil value`() throws {
     // given
     let json = """
       {
@@ -29,8 +29,8 @@ struct OptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Outcome should be keyNotFound when key is missing")
-  func missingKey() throws {
+  @Test
+  func `Outcome should be keyNotFound when key is missing`() throws {
     // given
     let json = """
       {}
@@ -48,8 +48,8 @@ struct OptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Outcome should be decodedSuccessfully for successful decoding")
-  func successfulDecoding() throws {
+  @Test
+  func `Outcome should be decodedSuccessfully for successful decoding`() throws {
     // given
     let json = """
       {
@@ -79,8 +79,8 @@ struct OptionalPolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("Should throw error for unknown type")
-  func unknownTypeThrowsError() throws {
+  @Test
+  func `Should throw error for unknown type`() throws {
     // given
     let json = """
       {
@@ -98,8 +98,8 @@ struct OptionalPolymorphicValueResilientTests {
     }
   }
 
-  @Test("Should throw error for invalid JSON format")
-  func invalidJSONThrowsError() throws {
+  @Test
+  func `Should throw error for invalid JSON format`() throws {
     // given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/OptionalValue/OptionalPolymorphicValueTests.swift
@@ -15,15 +15,15 @@ struct OptionalPolymorphicValueTests {
   func testDecodingOptionalPolymorphicValue() throws {
     // given
     let jsonData = #"""
-    {
-      "notice2" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      "notice3": null
-    }
-    """#
+      {
+        "notice2" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        },
+        "notice3": null
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(OptionalDummyResponse.self, from: Data(jsonData.utf8))
@@ -38,30 +38,13 @@ struct OptionalPolymorphicValueTests {
   }
 
   @Test
-  func decodingOptionalPolymorphicValueWhenEmptyObject() throws {
+  func `decoding optional polymorphic value when empty object`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice1" : {}
-    }
-    """#
-
-    // when & then
-    #expect(throws: DecodingError.self) {
-      _ = try JSONDecoder().decode(OptionalDummyResponse.self, from: Data(jsonData.utf8))
-    }
-  }
-
-  @Test
-  func decodingOptionalPolymorphicValueWhenMissingRequiredProperty() throws {
-    // given
-    let jsonData = #"""
-    {
-      "notice1" : {
-        "type" : "callout"
+      {
+        "notice1" : {}
       }
-    }
-    """#
+      """#
 
     // when & then
     #expect(throws: DecodingError.self) {
@@ -70,17 +53,34 @@ struct OptionalPolymorphicValueTests {
   }
 
   @Test
-  func encodingOptionalPolymorphicValueOmitsNilFields() throws {
+  func `decoding optional polymorphic value when missing required property`() throws {
+    // given
+    let jsonData = #"""
+      {
+        "notice1" : {
+          "type" : "callout"
+        }
+      }
+      """#
+
+    // when & then
+    #expect(throws: DecodingError.self) {
+      _ = try JSONDecoder().decode(OptionalDummyResponse.self, from: Data(jsonData.utf8))
+    }
+  }
+
+  @Test
+  func `encoding optional polymorphic value omits nil fields`() throws {
     // given
     let response = OptionalDummyResponse(
       notice1: DummyCallout(
         type: .callout,
         title: nil,
         description: "test",
-        icon: "test_icon"
+        icon: "test_icon",
       ),
       notice2: nil,
-      notice3: nil
+      notice3: nil,
     )
 
     // when
@@ -90,20 +90,20 @@ struct OptionalPolymorphicValueTests {
 
     // then - nil fields (notice2, notice3) are omitted, matching Apple's default Codable behavior
     let expectResult = #"""
-    {
-      "notice1" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
+      {
+        "notice1" : {
+          "description" : "test",
+          "icon" : "test_icon",
+          "type" : "callout"
+        }
       }
-    }
-    """#
+      """#
     let jsonString = try #require(String(bytes: data, encoding: .utf8))
     #expect(jsonString == expectResult)
   }
 
   @Test
-  func encodingDecodingOptionalPolymorphicValueRoundTrip() throws {
+  func `encoding decoding optional polymorphic value round trip`() throws {
     // given
     let response = OptionalDummyResponse(notice1: nil, notice2: nil, notice3: nil)
 

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/PolymorphicValueCodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/PolymorphicValueCodableDummy.swift
@@ -102,7 +102,7 @@ struct OptionalPolymorphicLossyArrayDummyResponse {
     DummyActionableCallout.self,
     DummyDismissibleCallout.self,
   ],
-  fallbackType: DummyUndefinedCallout.self
+  fallbackType: DummyUndefinedCallout.self,
 )
 public protocol DummyNotice: Codable, Equatable {
   var type: DummyNoticeType { get }
@@ -112,7 +112,7 @@ public protocol DummyNotice: Codable, Equatable {
 
 public enum DummyNoticeType: String, Codable, DefaultCodableStrategy {
 
-  public static let defaultValue = DummyNoticeType.undefinedCallout
+  public static let defaultValue: DummyNoticeType = .undefinedCallout
 
   case callout
   case actionableCallout = "actionable-callout"
@@ -146,8 +146,11 @@ struct DummyDismissibleCallout: DummyNotice {
 
 @PolymorphicCodable(identifier: "undefined-callout", codingKeyStyle: .snakeCase)
 struct DummyUndefinedCallout: DummyNotice {
+  // swiftformat:disable propertyTypes
+  // An explicit type annotation breaks generic inference of the @DefaultCodable wrapper.
   @DefaultCodable
   var type = DummyNoticeType.undefinedCallout
+  // swiftformat:enable propertyTypes
   let title: String?
   let description: String
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/PolymorphicValueDecodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/PolymorphicValueDecodableDummy.swift
@@ -78,7 +78,7 @@ struct OptionalLossyAarrayDummyDecodableResponse {
     DummyActionableDecodableCallout.self,
     DummyDismissibleDecodableCallout.self,
   ],
-  fallbackType: DummyUndefinedDecodableCallout.self
+  fallbackType: DummyUndefinedDecodableCallout.self,
 )
 protocol DummyDecodableNotice: Decodable {
   var type: DummyDecodableNoticeType { get }
@@ -88,7 +88,7 @@ protocol DummyDecodableNotice: Decodable {
 
 enum DummyDecodableNoticeType: String, Decodable, DefaultCodableStrategy {
 
-  static let defaultValue = DummyDecodableNoticeType.undefinedCallout
+  static let defaultValue: DummyDecodableNoticeType = .undefinedCallout
 
   case callout
   case actionableCallout = "actionable-callout"
@@ -122,8 +122,11 @@ struct DummyDismissibleDecodableCallout: DummyDecodableNotice {
 
 @PolymorphicDecodable(identifier: "undefined-callout", codingKeyStyle: .snakeCase)
 struct DummyUndefinedDecodableCallout: DummyDecodableNotice {
+  // swiftformat:disable propertyTypes
+  // An explicit type annotation breaks generic inference of the @DefaultCodable wrapper.
   @DefaultCodable
   var type = DummyDecodableNoticeType.undefinedCallout
+  // swiftformat:enable propertyTypes
   let title: String?
   let description: String
 }

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableDummy.swift
@@ -18,7 +18,7 @@ struct DummyFeedResponse: Codable {
 @UnnestedPolymorphicCodable(
   identifier: "TITLE_VIEW_ITEM",
   forKey: "data",
-  codingKeyStyle: .snakeCase
+  codingKeyStyle: .snakeCase,
 )
 struct TitleViewItem: ViewItem {
   let id: String
@@ -28,13 +28,13 @@ struct TitleViewItem: ViewItem {
 @UnnestedPolymorphicCodable(
   identifier: "EMPTY_VIEW_ITEM",
   forKey: "data",
-  codingKeyStyle: .snakeCase
+  codingKeyStyle: .snakeCase,
 )
 struct EmptyViewItem: ViewItem {}
 
 @UnnestedPolymorphicCodable(
   identifier: "SUBTITLE_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct SubtitleViewItem: ViewItem {
   let id: String
@@ -46,7 +46,7 @@ struct SubtitleViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "OPTIONAL_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct OptionalViewItem: ViewItem {
   let id: String
@@ -59,7 +59,7 @@ struct OptionalViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "CONSTANT_PROPERTY_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct ConstantPropertyViewItem: ViewItem {
   let id: String
@@ -70,7 +70,7 @@ struct ConstantPropertyViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "COMPUTED_PROPERTY_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct ComputedPropertyViewItem: ViewItem {
   let id: String
@@ -85,7 +85,7 @@ struct ComputedPropertyViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "STATIC_PROPERTY_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct StaticPropertyViewItem: ViewItem {
   let id: String
@@ -96,7 +96,7 @@ struct StaticPropertyViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "FUNCTION_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct FunctionViewItem: ViewItem {
   let id: String
@@ -113,7 +113,7 @@ struct FunctionViewItem: ViewItem {
 
 @UnnestedPolymorphicCodable(
   identifier: "COMPLEX_TYPE_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct ComplexTypeViewItem: ViewItem {
   let id: String

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableStrategy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicCodableStrategy.swift
@@ -20,6 +20,6 @@ import KarrotCodableKit
     StaticPropertyViewItem.self,
     FunctionViewItem.self,
     ComplexTypeViewItem.self,
-  ]
+  ],
 )
 protocol ViewItem {}

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicDecodableDummy.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/TestDoubles/UnnestedPolymorphicDecodableDummy.swift
@@ -18,7 +18,7 @@ struct DummyDecodingFeedResponse: Decodable {
 @UnnestedPolymorphicDecodable(
   identifier: "IMAGE_VIEW_ITEM",
   forKey: "default",
-  codingKeyStyle: .snakeCase
+  codingKeyStyle: .snakeCase,
 )
 struct ImageViewItem: ViewItem {
   let id: String
@@ -28,7 +28,7 @@ struct ImageViewItem: ViewItem {
 
 @UnnestedPolymorphicDecodable(
   identifier: "SUBTITLE_DECODABLE_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct SubtitleDecodableViewItem: ViewItem {
   let id: String
@@ -38,7 +38,7 @@ struct SubtitleDecodableViewItem: ViewItem {
 
 @UnnestedPolymorphicDecodable(
   identifier: "OPTIONAL_DECODABLE_VIEW_ITEM",
-  forKey: "data"
+  forKey: "data",
 )
 struct OptionalDecodableViewItem: ViewItem {
   let id: String

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicCodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicCodableTests.swift
@@ -12,25 +12,25 @@ import KarrotCodableKit
 
 struct UnnestedPolymorphicCodableTests {
   @Test
-  func decodingUnnestedPolymorphicCodable() async throws {
+  func `decoding unnested polymorphic codable`() throws {
     // given
     let jsonData = #"""
-    {
-      "items": [
-        {
-          "type": "TITLE_VIEW_ITEM",
-          "data": {
-            "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
-            "item_title": "Hello, world!"
+      {
+        "items": [
+          {
+            "type": "TITLE_VIEW_ITEM",
+            "data": {
+              "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
+              "item_title": "Hello, world!"
+            }
+          },
+          {
+            "type": "EMPTY_VIEW_ITEM",
+            "data": {}
           }
-        },
-        {
-          "type": "EMPTY_VIEW_ITEM",
-          "data": {}
-        }
-      ]
-    }
-    """#
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DummyFeedResponse.self, from: Data(jsonData.utf8))
@@ -46,13 +46,13 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func encodingUnnestedPolymorphicCodable() async throws {
+  func `encoding unnested polymorphic codable`() throws {
     // given
     let response = DummyFeedResponse(
       items: [
         TitleViewItem(
           id: "1e243b34-b8a6-41c8-b08f-cba8d014021f",
-          itemTitle: "Hello, world!"
+          itemTitle: "Hello, world!",
         ),
         EmptyViewItem(),
       ]
@@ -65,30 +65,30 @@ struct UnnestedPolymorphicCodableTests {
 
     // then
     let expectResult = #"""
-    {
-      "items" : [
-        {
-          "data" : {
-            "id" : "1e243b34-b8a6-41c8-b08f-cba8d014021f",
-            "item_title" : "Hello, world!"
+      {
+        "items" : [
+          {
+            "data" : {
+              "id" : "1e243b34-b8a6-41c8-b08f-cba8d014021f",
+              "item_title" : "Hello, world!"
+            },
+            "type" : "TITLE_VIEW_ITEM"
           },
-          "type" : "TITLE_VIEW_ITEM"
-        },
-        {
-          "data" : {
+          {
+            "data" : {
 
-          },
-          "type" : "EMPTY_VIEW_ITEM"
-        }
-      ]
-    }
-    """#
+            },
+            "type" : "EMPTY_VIEW_ITEM"
+          }
+        ]
+      }
+      """#
     let jsonString = String(decoding: data, as: UTF8.self)
     #expect(jsonString == expectResult)
   }
 
   @Test
-  func unnestedPolymorphicCodableWithOptionalPropertiesMissingKeys() async throws {
+  func `unnested polymorphic codable with optional properties missing keys`() throws {
     // given
     let json = """
       {
@@ -112,7 +112,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableWithOptionalPropertiesPartialData() async throws {
+  func `unnested polymorphic codable with optional properties partial data`() throws {
     // given
     let json = """
       {
@@ -138,7 +138,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableWithRequiredPropertyMissing() async throws {
+  func `unnested polymorphic codable with required property missing`() throws {
     // given
     let json = """
       {
@@ -160,7 +160,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableWithMissingNestedDataKey() async throws {
+  func `unnested polymorphic codable with missing nested data key`() throws {
     // given
     let json = """
       {
@@ -179,7 +179,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableEncodingWithOptionalProperties() async throws {
+  func `unnested polymorphic codable encoding with optional properties`() throws {
     // given
     let item = OptionalViewItem(id: "test123", title: "Test Title", count: nil, url: nil)
 
@@ -202,13 +202,13 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableRoundTripWithOptionalProperties() async throws {
+  func `unnested polymorphic codable round trip with optional properties`() throws {
     // given
     let originalItem = OptionalViewItem(
       id: "test123",
       title: "Test Title",
       count: 42,
-      url: URL(string: "https://example.com")
+      url: URL(string: "https://example.com"),
     )
 
     // when
@@ -226,7 +226,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func unnestedPolymorphicCodableWithWrongDataType() async throws {
+  func `unnested polymorphic codable with wrong data type`() throws {
     // given
     let json = """
       {
@@ -248,11 +248,11 @@ struct UnnestedPolymorphicCodableTests {
   // MARK: - Edge Case Tests
 
   @Test
-  func constantPropertiesEncodingTest() async throws {
+  func `constant properties encoding test`() throws {
     // given
     let originalItem = ConstantPropertyViewItem(
       id: "test123",
-      title: "Test Title"
+      title: "Test Title",
     )
 
     // when - encoding
@@ -276,7 +276,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func constantPropertiesDecodingTest() async throws {
+  func `constant properties decoding test`() throws {
     // given
     let decodingJson = """
       {
@@ -303,11 +303,11 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func computedPropertiesEncodingTest() async throws {
+  func `computed properties encoding test`() throws {
     // given
     let originalItem = ComputedPropertyViewItem(
       id: "test123",
-      title: "Test Title"
+      title: "Test Title",
     )
 
     // when - encoding
@@ -324,7 +324,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func computedPropertiesDecodingTest() async throws {
+  func `computed properties decoding test`() throws {
     // given
     let decodingJson = """
       {
@@ -349,11 +349,11 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func staticPropertiesEncodingTest() async throws {
+  func `static properties encoding test`() throws {
     // given
     let originalItem = StaticPropertyViewItem(
       id: "test123",
-      title: "Test Title"
+      title: "Test Title",
     )
 
     // when - encoding
@@ -370,7 +370,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func staticPropertiesDecodingTest() async throws {
+  func `static properties decoding test`() throws {
     // given
     let decodingJson = """
       {
@@ -395,11 +395,11 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func functionsEncodingTest() async throws {
+  func `functions encoding test`() throws {
     // given
     let originalItem = FunctionViewItem(
       id: "test123",
-      title: "Test Title"
+      title: "Test Title",
     )
 
     // when - encoding
@@ -416,7 +416,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func functionsDecodingTest() async throws {
+  func `functions decoding test`() throws {
     // given
     let decodingJson = """
       {
@@ -441,7 +441,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func complexTypesEncodingTest() async throws {
+  func `complex types encoding test`() throws {
     // given
     let nestedStruct = NestedStruct(name: "test", value: 123)
     let optionalNested = NestedStruct(name: "optional", value: 456)
@@ -450,7 +450,7 @@ struct UnnestedPolymorphicCodableTests {
       tags: ["tag1", "tag2", "tag3"],
       metadata: ["key1": "value1", "key2": "value2"],
       nestedStruct: nestedStruct,
-      optionalNestedStruct: optionalNested
+      optionalNestedStruct: optionalNested,
     )
 
     // when - encoding
@@ -469,7 +469,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func complexTypesDecodingTest() async throws {
+  func `complex types decoding test`() throws {
     // given
     let nestedStruct = NestedStruct(name: "test", value: 123)
     let optionalNested = NestedStruct(name: "optional", value: 456)
@@ -478,7 +478,7 @@ struct UnnestedPolymorphicCodableTests {
       tags: ["tag1", "tag2", "tag3"],
       metadata: ["key1": "value1", "key2": "value2"],
       nestedStruct: nestedStruct,
-      optionalNestedStruct: optionalNested
+      optionalNestedStruct: optionalNested,
     )
 
     // when - encoding to get test data
@@ -501,7 +501,7 @@ struct UnnestedPolymorphicCodableTests {
   }
 
   @Test
-  func complexTypesWithMissingOptionalProperties() async throws {
+  func `complex types with missing optional properties`() throws {
     // given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicDecodableTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/UnnestedPolymorphicTests/UnnestedPolymorphicDecodableTests.swift
@@ -13,22 +13,22 @@ import KarrotCodableKit
 struct UnnestedPolymorphicDecodableTests {
 
   @Test
-  func decodingUnnestedPolymorphicCodable() async throws {
+  func `decoding unnested polymorphic codable`() throws {
     // given
     let jsonData = #"""
-    {
-      "items": [
-        {
-          "type": "IMAGE_VIEW_ITEM",
-          "default": {
-            "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
-            "image_url": "https://karrotmarket.com",
-            "class": "1-A"
+      {
+        "items": [
+          {
+            "type": "IMAGE_VIEW_ITEM",
+            "default": {
+              "id": "1e243b34-b8a6-41c8-b08f-cba8d014021f",
+              "image_url": "https://karrotmarket.com",
+              "class": "1-A"
+            }
           }
-        }
-      ]
-    }
-    """#
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DummyDecodingFeedResponse.self, from: Data(jsonData.utf8))
@@ -44,7 +44,7 @@ struct UnnestedPolymorphicDecodableTests {
   }
 
   @Test
-  func unnestedPolymorphicDecodableWithOptionalPropertiesMissingKeys() async throws {
+  func `unnested polymorphic decodable with optional properties missing keys`() throws {
     // given
     let json = """
       {
@@ -68,7 +68,7 @@ struct UnnestedPolymorphicDecodableTests {
   }
 
   @Test
-  func unnestedPolymorphicDecodableWithOptionalPropertiesPartialData() async throws {
+  func `unnested polymorphic decodable with optional properties partial data`() throws {
     // given
     let json = """
       {
@@ -94,7 +94,7 @@ struct UnnestedPolymorphicDecodableTests {
   }
 
   @Test
-  func unnestedPolymorphicDecodableWithRequiredPropertyMissing() async throws {
+  func `unnested polymorphic decodable with required property missing`() throws {
     // given
     let json = """
       {
@@ -116,7 +116,7 @@ struct UnnestedPolymorphicDecodableTests {
   }
 
   @Test
-  func unnestedPolymorphicDecodableWithMissingNestedDataKey() async throws {
+  func `unnested polymorphic decodable with missing nested data key`() throws {
     // given
     let json = """
       {
@@ -135,7 +135,7 @@ struct UnnestedPolymorphicDecodableTests {
   }
 
   @Test
-  func unnestedPolymorphicDecodableWithWrongDataType() async throws {
+  func `unnested polymorphic decodable with wrong data type`() throws {
     // given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueResilientTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueResilientTests.swift
@@ -15,8 +15,8 @@ struct PolymorphicValueResilientTests {
     @DummyNotice.Polymorphic var notice: any DummyNotice
   }
 
-  @Test("projected value provides error information")
-  func projectedValueProvidesErrorInfo() throws {
+  @Test
+  func `projected value provides error information`() throws {
     // given
     let json = """
       {
@@ -44,8 +44,8 @@ struct PolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("unknown type handling with fallback")
-  func unknownType() throws {
+  @Test
+  func `unknown type handling with fallback`() throws {
     // given
     let json = """
       {
@@ -74,8 +74,8 @@ struct PolymorphicValueResilientTests {
     #endif
   }
 
-  @Test("null values handling")
-  func nullValues() async throws {
+  @Test
+  func `null values handling`() async throws {
     // given
     let json = """
       {
@@ -99,8 +99,8 @@ struct PolymorphicValueResilientTests {
     }
   }
 
-  @Test("error reporting with JSONDecoder")
-  func errorReporting() async throws {
+  @Test
+  func `error reporting with JSONDecoder`() async throws {
     /// given
     let json = """
       {

--- a/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueTests.swift
+++ b/Tests/KarrotCodableKitTests/PolymorphicCodable/Value/PolymorphicValueTests.swift
@@ -6,14 +6,15 @@
 //  Copyright © 2025 Danggeun Market Inc. All rights reserved.
 //
 
-import Testing
 import Foundation
+import Testing
 
 import KarrotCodableKit
 
 struct PolymorphicValueTests {
 
-  @Test func testEncodingPolymorphicValue() throws {
+  @Test
+  func `encoding polymorphic value`() throws {
     // given
     let response = DummyResponse(
       notice: DummyCallout(type: .callout, title: nil, description: "test", icon: "test_icon"),
@@ -22,39 +23,39 @@ struct PolymorphicValueTests {
           type: .actionableCallout,
           title: nil,
           description: "test",
-          action: URL(string: "https://daangn.com")!
+          action: try #require(URL(string: "https://daangn.com")),
         ),
         DummyDismissibleCallout(
           type: .dismissibleCallout,
           title: "test_title",
           description: "test",
-          key: "key"
+          key: "key",
         ),
-      ]
+      ],
     )
 
     let expectResult = #"""
-    {
-      "notice" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      "notices" : [
-        {
-          "action" : "https:\/\/daangn.com",
+      {
+        "notice" : {
           "description" : "test",
-          "type" : "actionable-callout"
+          "icon" : "test_icon",
+          "type" : "callout"
         },
-        {
-          "description" : "test",
-          "key" : "key",
-          "title" : "test_title",
-          "type" : "dismissible-callout"
-        }
-      ]
-    }
-    """#
+        "notices" : [
+          {
+            "action" : "https:\/\/daangn.com",
+            "description" : "test",
+            "type" : "actionable-callout"
+          },
+          {
+            "description" : "test",
+            "key" : "key",
+            "title" : "test_title",
+            "type" : "dismissible-callout"
+          }
+        ]
+      }
+      """#
 
     // when
     let encoder = JSONEncoder()
@@ -66,35 +67,36 @@ struct PolymorphicValueTests {
     #expect(jsonString == expectResult)
   }
 
-  @Test func testDecodingPolymorphicValue() throws {
+  @Test
+  func `decoding polymorphic value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      "notices" : [
-        {
-          "action" : "https:\/\/daangn.com",
+      {
+        "notice" : {
           "description" : "test",
-          "type" : "actionable-callout"
+          "icon" : "test_icon",
+          "type" : "callout"
         },
-        {
-          "description" : "test",
-          "key" : "key",
-          "title" : "test_title",
-          "type" : "dismissible-callout"
-        },
-        {
-          "description" : "test",
-          "title" : "test_title",
-          "type" : "unknown-callout-type"
-        }
-      ]
-    }
-    """#
+        "notices" : [
+          {
+            "action" : "https:\/\/daangn.com",
+            "description" : "test",
+            "type" : "actionable-callout"
+          },
+          {
+            "description" : "test",
+            "key" : "key",
+            "title" : "test_title",
+            "type" : "dismissible-callout"
+          },
+          {
+            "description" : "test",
+            "title" : "test_title",
+            "type" : "unknown-callout-type"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DummyResponse.self, from: Data(jsonData.utf8))
@@ -107,23 +109,24 @@ struct PolymorphicValueTests {
     #expect(result.notices[2].type == .undefinedCallout)
   }
 
-  @Test func testDecodingUndefinedPolymorphicValue() throws {
+  @Test
+  func `decoding undefined polymorphic value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice" : {
-        "description" : "test1",
-        "icon" : "test_icon",
-        "type" : "unknown-callout-type"
-      },
-      "notices": [
-        {
-          "description" : "test2",
-          "type" : "unknown-type"
-        }
-      ]
-    }
-    """#
+      {
+        "notice" : {
+          "description" : "test1",
+          "icon" : "test_icon",
+          "type" : "unknown-callout-type"
+        },
+        "notices": [
+          {
+            "description" : "test2",
+            "type" : "unknown-type"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DummyResponse.self, from: Data(jsonData.utf8))
@@ -136,35 +139,36 @@ struct PolymorphicValueTests {
 }
 
 extension PolymorphicValueTests {
-  @Test func testDecodingOnlyValue() throws {
+  @Test
+  func `decoding only value`() throws {
     // given
     let jsonData = #"""
-    {
-      "notice" : {
-        "description" : "test",
-        "icon" : "test_icon",
-        "type" : "callout"
-      },
-      "notices" : [
-        {
-          "action" : "https:\/\/daangn.com",
+      {
+        "notice" : {
           "description" : "test",
-          "type" : "actionable-callout"
+          "icon" : "test_icon",
+          "type" : "callout"
         },
-        {
-          "description" : "test",
-          "key" : "key",
-          "title" : "test_title",
-          "type" : "dismissible-callout"
-        },
-        {
-          "description" : "test",
-          "title" : "test_title",
-          "type" : "unknown-callout-type"
-        }
-      ]
-    }
-    """#
+        "notices" : [
+          {
+            "action" : "https:\/\/daangn.com",
+            "description" : "test",
+            "type" : "actionable-callout"
+          },
+          {
+            "description" : "test",
+            "key" : "key",
+            "title" : "test_title",
+            "type" : "dismissible-callout"
+          },
+          {
+            "description" : "test",
+            "title" : "test_title",
+            "type" : "unknown-callout-type"
+          }
+        ]
+      }
+      """#
 
     // when
     let result = try JSONDecoder().decode(DummyDecodableResponse.self, from: Data(jsonData.utf8))

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomCodableMacroTests.swift
@@ -49,7 +49,7 @@ final class CustomCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -81,7 +81,7 @@ final class CustomCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -130,7 +130,7 @@ extension CustomCodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -179,7 +179,7 @@ extension CustomCodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -224,7 +224,7 @@ extension CustomCodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -269,7 +269,7 @@ extension CustomCodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -300,16 +300,16 @@ extension CustomCodableMacroTests {
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomDecodableMacroTests.swift
@@ -49,7 +49,7 @@ final class CustomDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -81,7 +81,7 @@ final class CustomDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -130,7 +130,7 @@ extension CustomDecodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -179,7 +179,7 @@ extension CustomDecodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -224,7 +224,7 @@ extension CustomDecodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -269,7 +269,7 @@ extension CustomDecodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -300,16 +300,16 @@ extension CustomDecodableMacroTests {
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/CustomCodableMacros/CustomEncodableMacroTests.swift
@@ -49,7 +49,7 @@ final class CustomEncodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -81,7 +81,7 @@ final class CustomEncodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -130,7 +130,7 @@ extension CustomEncodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -179,7 +179,7 @@ extension CustomEncodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -224,7 +224,7 @@ extension CustomEncodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -269,7 +269,7 @@ extension CustomEncodableMacroTests {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -300,16 +300,16 @@ extension CustomEncodableMacroTests {
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "`@CustomCodable`, `@CustomEncodable`, `@CustomDecodable` cannot be applied to enum",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/Extenstions/StringSnakeCaseTests.swift
+++ b/Tests/KarrotCodableMacrosTests/Extenstions/StringSnakeCaseTests.swift
@@ -19,7 +19,8 @@ import Testing
 @testable import KarrotCodableKitMacros
 
 struct StringSnakeCaseTests {
-  @Test func test_convert_to_snake_case() {
+  @Test
+  func `convert to snake case`() {
     // given
     let toSnakeCaseTests: [(camelCase: String, snake_case: String)] = [
       ("simpleOneTwo", "simple_one_two"),

--- a/Tests/KarrotCodableMacrosTests/Extenstions/TrimmingBackticksTests.swift
+++ b/Tests/KarrotCodableMacrosTests/Extenstions/TrimmingBackticksTests.swift
@@ -10,7 +10,7 @@ import Testing
 @testable import KarrotCodableKitMacros
 
 struct TrimmingBackticksTests {
-  @Test("Trimming backticks", arguments: [
+  @Test(arguments: [
     ("``", ""),
     ("```", ""),
     ("`class`", "class"),
@@ -25,7 +25,7 @@ struct TrimmingBackticksTests {
     ("`while`", "while"),
     ("`do`", "do"),
   ])
-  func trimmingBackticks(testValues: (given: String, then: String)) async throws {
+  func `Trimming backticks`(testValues: (given: String, then: String)) {
     #expect(testValues.given.trimmingBackticks == testValues.then)
   }
 }

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableMacroTests.swift
@@ -20,7 +20,7 @@ final class PolymorphicCodableMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicCodable": PolymorphicCodableMacro.self,
+    "PolymorphicCodable": PolymorphicCodableMacro.self
   ]
   #endif
 
@@ -64,7 +64,7 @@ final class PolymorphicCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -104,11 +104,11 @@ final class PolymorphicCodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableStrategyProvidingMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicCodableStrategyProvidingMacroTests.swift
@@ -20,7 +20,7 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicCodableStrategyProviding": PolymorphicCodableStrategyProvidingMacro.self,
+    "PolymorphicCodableStrategyProviding": PolymorphicCodableStrategyProvidingMacro.self
   ]
   #endif
 
@@ -89,7 +89,7 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -159,7 +159,7 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -194,11 +194,11 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Macro must be attached to a protocol.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -249,11 +249,11 @@ final class PolymorphicCodableStrategyProvidingMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid identifierCodingKey: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicDeodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicDeodableMacroTests.swift
@@ -20,7 +20,7 @@ final class PolymorphicDecodableMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicDecodable": PolymorphicDecodableMacro.self,
+    "PolymorphicDecodable": PolymorphicDecodableMacro.self
   ]
   #endif
 
@@ -64,7 +64,7 @@ final class PolymorphicDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -107,11 +107,11 @@ final class PolymorphicDecodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicEncodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/PolymorphicCodableMacrosTests/PolymorphicEncodableMacroTests.swift
@@ -20,7 +20,7 @@ final class PolymorphicEncodableMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "PolymorphicEncodable": PolymorphicEncodableMacro.self,
+    "PolymorphicEncodable": PolymorphicEncodableMacro.self
   ]
   #endif
 
@@ -64,7 +64,7 @@ final class PolymorphicEncodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -107,11 +107,11 @@ final class PolymorphicEncodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
-        ),
+          column: 1,
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicCodableMacroTests.swift
@@ -18,7 +18,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "UnnestedPolymorphicCodable": UnnestedPolymorphicCodableMacro.self,
+    "UnnestedPolymorphicCodable": UnnestedPolymorphicCodableMacro.self
   ]
   #endif
 
@@ -110,7 +110,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -175,7 +175,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -230,7 +230,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -299,7 +299,7 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -331,16 +331,16 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "`@UnnestedPolymorphicCodable` cannot be applied to enum types. Use `@PolymorphicEnumCodable` instead.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "`@UnnestedPolymorphicCodable` cannot be applied to enum types. Use `@PolymorphicEnumCodable` instead.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -370,16 +370,16 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -452,12 +452,12 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
           column: 3,
           severity: .warning,
           fixIts: [
-            FixItSpec(message: "Make the property mutable instead"),
-          ]
-        ),
+            FixItSpec(message: "Make the property mutable instead")
+          ],
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -487,16 +487,16 @@ final class UnnestedPolymorphicCodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid nested key: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "Invalid nested key: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
+++ b/Tests/KarrotCodableMacrosTests/UnnestedPolymorphicCodableMacroTests/UnnestedPolymorphicDecodableMacroTests.swift
@@ -17,7 +17,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
 
   #if canImport(KarrotCodableKitMacros)
   let testMacros: [String: Macro.Type] = [
-    "UnnestedPolymorphicDecodable": UnnestedPolymorphicDecodableMacro.self,
+    "UnnestedPolymorphicDecodable": UnnestedPolymorphicDecodableMacro.self
   ]
   #endif
 
@@ -94,7 +94,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -148,7 +148,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -195,7 +195,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -252,7 +252,7 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         }
         """,
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -284,16 +284,16 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "`@UnnestedPolymorphicDecodable` cannot be applied to enum types. Use `@PolymorphicEnumDecodable` instead.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "`@UnnestedPolymorphicDecodable` cannot be applied to enum types. Use `@PolymorphicEnumDecodable` instead.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -323,16 +323,16 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "Invalid polymorphic identifier: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -394,12 +394,12 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
           column: 3,
           severity: .warning,
           fixIts: [
-            FixItSpec(message: "Make the property mutable instead"),
-          ]
-        ),
+            FixItSpec(message: "Make the property mutable instead")
+          ],
+        )
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")
@@ -429,16 +429,16 @@ final class UnnestedPolymorphicDecodableMacroTests: XCTestCase {
         DiagnosticSpec(
           message: "Invalid nested key: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
         DiagnosticSpec(
           message: "Invalid nested key: expected a non-empty string.",
           line: 1,
-          column: 1
+          column: 1,
         ),
       ],
       macros: testMacros,
-      indentationWidth: .spaces(2)
+      indentationWidth: .spaces(2),
     )
     #else
     throw XCTSkip("macros are only supported when running tests for the host platform")


### PR DESCRIPTION
## What

Run `swiftformat .` across the codebase (153 files) with the house-style configuration (2-space indent, 120-column limit). Notable mechanical changes:

- import sorting (`testable-bottom`), attribute placement (`prev-line`), multiline string re-indentation, trailing commas in multi-element lists
- Swift Testing test names converted to raw identifiers by `swiftTestingTestCaseNames` (e.g. `func testPolymorphicEnumValue()` → ``func `polymorphic enum value`()``)

The `.swiftformat` / `.swiftlint.yml` configuration files themselves are intentionally not part of this PR.

## Manual accompaniments (kept the build green)

- `CodingUserInfoKey.resilientDecodingErrorReporter` is written as `: CodingUserInfoKey = .init(...)!` — the `propertyTypes` rule miscompiles the multiline `= CodingUserInfoKey(...)!` form into a tuple (SwiftFormat 0.62.1 bug). The `.init` form is stable under re-runs.
- The `@DefaultCodable` test doubles are wrapped in `swiftformat:disable propertyTypes` regions — an explicit type annotation breaks the wrapper's generic parameter inference.

## Verification

- `swiftformat .` is idempotent on the final tree.
- `swift test` passes in debug (303) and release (295) configurations.

## Notes

- Stacked on #29; retarget to `main` after it merges. Formatting only — no behavior changes beyond the two accompaniments above.

https://claude.ai/code/session_017kn3Hf2khxiFy1TqimTGx9
