### PR TITLE
chore: set up agent and contributor experience

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.swift) command -v swiftformat >/dev/null && swiftformat \"$f\";; esac; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.swift) if [ -f \"${CLAUDE_PROJECT_DIR:-.}/.swiftlint.yml\" ]; then command -v swiftlint >/dev/null && swiftlint lint --strict --quiet \"$f\"; fi;; esac; }"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report incorrect behavior in KarrotCodableKit
+labels: ["Bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: KarrotCodableKit version
+      placeholder: "2.1.0"
+    validations:
+      required: true
+  - type: input
+    id: toolchain
+    attributes:
+      label: Swift / Xcode version
+      placeholder: "Swift 6.2 / Xcode 26.3"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform and OS version
+      placeholder: "iOS 18.5 simulator"
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior. Include the full error output (e.g. the `DecodingError`) if any.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproducible code
+      description: The smallest type + decoding/encoding code that reproduces the issue.
+      render: swift
+    validations:
+      required: true
+  - type: textarea
+    id: json
+    attributes:
+      label: JSON payload
+      description: The JSON involved, if the bug is about decoding or encoding.
+      render: json
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and found no duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest new functionality for KarrotCodableKit
+labels: ["Feature"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Problem / motivation
+      description: What problem would this solve? What are you trying to do that is currently hard or impossible?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or solution
+      description: Sketch the API you have in mind, if any.
+      render: swift
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to submit a PR for this.
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,10 @@
 ## Review Notes
 <!-- Include any information that would help with the review. -->
 - 
+
+## Checklist
+<!-- Check what applies to this PR. -->
+- [ ] `swift test -c debug` and `swift test -c release` pass (test counts reported above)
+- [ ] Changes are covered by tests (for bug fixes: a regression test written first)
+- [ ] `swiftformat .` produces no diff
+- [ ] Docs updated if the public API changed

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,137 @@
+# SwiftFormat configuration for KarrotCodableKit.
+#
+# Based on the Karrot house style applied across this codebase in PR #30
+# (SwiftFormat 0.62.x). Uses an explicit rule whitelist: only the rules listed
+# under "rules" below run; everything else is disabled.
+#
+# `swiftformat .` must stay idempotent on a clean tree. Verify with:
+#   swiftformat --lint .
+#
+# Deliberate deviations from the house baseline, so the existing tree stays
+# untouched: isEmpty, wrapIfStatementBodies, and elseOnSameLine are not
+# enabled (tests intentionally assert `count == 0` for better failure
+# messages, and a few single-line if/else bodies are kept as written).
+
+# options
+--min-version 0.62.0
+--swift-version 6.2
+--language-mode 5
+--self remove # redundantSelf
+--import-grouping testable-bottom # sortedImports
+--trailing-commas multi-element-lists # trailingCommas
+--trim-whitespace always # trailingSpace
+--indent 2 #indent
+--ifdef no-indent #indent
+--indent-strings true #indent
+--wrap-arguments before-first # wrapArguments
+--wrap-parameters before-first # wrapArguments
+--wrap-collections before-first # wrapArguments
+--wrap-conditions before-first # wrapArguments
+--wrap-return-type never #wrapArguments
+--wrap-effects never #wrapArguments
+--closing-paren balanced # wrapArguments
+--call-site-paren balanced # wrapArguments
+--wrap-type-aliases before-first # wrapArguments
+--func-attributes prev-line # wrapAttributes
+--computed-var-attributes prev-line # wrapAttributes
+--stored-var-attributes preserve # wrapAttributes
+--complex-attributes prev-line # wrapAttributes
+--type-attributes prev-line # wrapAttributes
+--wrap-ternary before-operators # wrap
+--extension-acl on-declarations # extensionAccessControl
+--pattern-let inline # hoistPatternLet
+--property-types infer-locals-only # redundantType, propertyTypes
+--strip-unused-args closure-only # unusedArguments
+--type-blank-lines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--ranges preserve # spaceAroundOperators
+--some-any disabled # opaqueGenericParameters
+--single-line-for-each convert # preferForLoop
+--short-optionals always # typeSugar
+--semicolons never # semicolons
+--doc-comments preserve # docComments
+--max-width 120 # wrap
+--modifier-order private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),override,final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,unowned(safe),unowned(unsafe),static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix,async # modifierOrder
+
+# rules
+--rules anyObjectProtocol
+--rules blankLinesBetweenScopes
+--rules consecutiveSpaces
+--rules consecutiveBlankLines
+--rules duplicateImports
+--rules extensionAccessControl
+--rules environmentEntry
+--rules hoistPatternLet
+--rules indent
+--rules redundantParens
+--rules redundantReturn
+--rules redundantSelf
+--rules redundantType
+--rules redundantPattern
+--rules redundantGet
+--rules redundantFileprivate
+--rules redundantRawValues
+--rules redundantEquatable
+--rules sortImports
+--rules sortDeclarations
+--rules strongifiedSelf
+--rules trailingCommas
+--rules trailingSpace
+--rules linebreakAtEndOfFile
+--rules typeSugar
+--rules wrap
+--rules wrapMultilineStatementBraces
+--rules wrapArguments
+--rules wrapAttributes
+--rules wrapLoopBodies
+--rules braces
+--rules redundantClosure
+--rules redundantInit
+--rules redundantVoidReturnType
+--rules redundantOptionalBinding
+--rules redundantInternal
+--rules redundantVariable
+--rules unusedArguments
+--rules spaceInsideBrackets
+--rules spaceInsideBraces
+--rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
+--rules spaceAroundOperators
+--rules enumNamespaces
+--rules blockComments
+--rules docComments
+--rules docCommentsBeforeModifiers
+--rules spaceAroundComments
+--rules spaceInsideComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope
+--rules emptyBraces
+--rules andOperator
+--rules opaqueGenericParameters
+--rules genericExtensions
+--rules trailingClosures
+--rules sortTypealiases
+--rules preferForLoop
+--rules conditionalAssignment
+--rules wrapMultilineConditionalAssignment
+--rules void
+--rules blankLineAfterSwitchCase
+--rules consistentSwitchCaseSpacing
+--rules semicolons
+--rules propertyTypes
+--rules blankLinesBetweenChainedFunctions
+--rules emptyExtensions
+--rules preferCountWhere
+--rules preferFirstWhere
+--rules preferContains
+--rules swiftTestingTestCaseNames
+--rules modifiersOnSameLine
+--rules noForceTryInTests
+--rules noForceUnwrapInTests
+--rules redundantThrows
+--rules redundantAsync
+--rules noGuardInTests
+--rules redundantMemberwiseInit
+--rules redundantTypedThrows
+--rules redundantBreak
+--rules preferFinalClasses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ swift test --filter TestClassName                 # Specific test class
 swift test --filter TestClassName.testMethodName  # Specific test method
 swift test --filter UnnestedPolymorphic           # Tests matching pattern
 swiftformat .                 # Format (config: .swiftformat in repo root)
+swiftformat --lint .          # Verify formatting (must report 0 files requiring formatting)
 swift package resolve|update|clean|reset          # Package management
 ```
 
@@ -84,9 +85,15 @@ Adding a new UnnestedPolymorphic macro variant:
 3. Use template methods from the protocol extension for common functionality
 4. Register the macro in `KarrotCodableKitPlugin.swift`
 
+### Documentation & Provenance
+- Feature docs: `Docs/AnyCodable/README.md`, `Docs/BetterCodable/README.md`; the README "Key Features" section holds macro-expansion examples. Update these when the public API changes.
+- API reference (DocC) is built and hosted by Swift Package Index via `.spi.yml` — there is no local DocC catalog.
+- AnyCodable, BetterCodable, and Resilient are ports of Flight-School/AnyCodable, marksands/BetterCodable, and airbnb/ResilientDecoding. Keep behavior parity with BetterCodable when touching wrapper policies, and add attribution under `ThirdPartyLicenses/` when vendoring upstream code.
+
 ## Code Style
 
 - `.swiftformat` (repo root) is the source of truth: rule whitelist, 2-space indent, 120-column limit. Run `swiftformat .` before committing — it must produce no diff.
+- Claude Code auto-formats edited Swift files via the PostToolUse hook in `.claude/settings.json` — an unexpected post-edit diff is usually just the formatter.
 - Multiline string literals (JSON fixtures, expected macro expansions) indent their content and closing `"""` two spaces past the opening line; `--indent-strings true` preserves this — do not "fix" it.
 - `#if DEBUG` blocks add no extra indentation (`--ifdef no-indent`).
 - propertyTypes rule gotchas:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+Canonical instructions for AI coding agents working in this repository.
+`CLAUDE.md` and `GEMINI.md` import this file — edit this file, not those.
+Human-facing contribution docs live in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Project Overview
+
+KarrotCodableKit is a public Swift package that extends Swift's `Codable` protocol:
+
+- **CustomCodable**: Macro-based custom encoding/decoding with configurable coding key styles
+- **PolymorphicCodable**: Polymorphic types with automatic type resolution based on identifiers
+- **AnyCodable**: Type-erased Codable values for handling various types
+- **BetterCodable**: Property wrappers for dates, data values, defaults, and lossy conversions
+
+Package facts:
+
+- Library product `KarrotCodableKit`; targets `KarrotCodableKit` (runtime) and `KarrotCodableKitMacros` (SwiftSyntax macro plugin)
+- `swift-tools-version: 5.9`, dependency `swift-syntax` `509.0.0..<604.0.0`
+- Platforms: macOS 11, iOS 13, tvOS 13, watchOS 6, macCatalyst 13
+- Building the test suite requires a **Swift 6.2+ toolchain** (raw-identifier test names, SE-0451); CI uses macOS 15 + Xcode 26.3
+
+## Commands
+
+```bash
+swift build                   # Build all targets
+swift test                    # Run all tests (debug)
+swift test -c release         # Release configuration tests
+swift test --filter TestClassName                 # Specific test class
+swift test --filter TestClassName.testMethodName  # Specific test method
+swift test --filter UnnestedPolymorphic           # Tests matching pattern
+swiftformat .                 # Format (config: .swiftformat in repo root)
+swift package resolve|update|clean|reset          # Package management
+```
+
+Done criteria for any code change: `swift test` passes in **both `-c debug` and `-c release`** with zero failures. The debug count is higher than release (DEBUG-only APIs such as `outcome`/projected values have DEBUG-only tests) — that difference is expected. `swiftformat .` must produce no diff before committing.
+
+## Architecture
+
+### Core Modules
+- **KarrotCodableKit**: Main library target containing runtime functionality
+- **KarrotCodableKitMacros**: Swift macro implementations using SwiftSyntax
+
+### Key Components
+- **CustomCodable/**: Macro system for automated Codable implementations with CodingKey generation
+- **PolymorphicCodable/**: Runtime polymorphic type resolution system with strategy-based decoding
+  - **Value Wrappers**: `PolymorphicValue`, `OptionalPolymorphicValue`, `LossyOptionalPolymorphicValue`
+  - **Array Wrappers**: `PolymorphicArrayValue`, `OptionalPolymorphicArrayValue`, `DefaultEmptyPolymorphicArrayValue`, `PolymorphicLossyArrayValue`, `OptionalPolymorphicLossyArrayValue`
+- **AnyCodable/**: Type erasure wrappers (AnyCodable, AnyEncodable, AnyDecodable)
+- **BetterCodable/**: Property wrappers for common Codable patterns
+  - **DateValue/OptionalDateValue**: Date formatting strategies (ISO8601, RFC3339, Timestamp, etc.)
+  - **LosslessValue**: Lossless type conversion (preserves original type, restores on encoding)
+  - **LossyArray/LossyDictionary/LossyOptional**: Lossy decoding (filters out failed elements)
+  - **Defaults**: Default value handling (DefaultCodable, DefaultEmptyArray, etc.)
+- **Resilient/**: DEBUG mode decoding error tracking and reporting system
+  - `ResilientDecodingOutcome`: Decoding result states (decodedSuccessfully, keyNotFound, valueWasNil, recoveredFrom)
+  - `ResilientDecodingErrorReporter`: Error collection and hierarchical storage by coding path
+  - Accessible via `outcome` property on all BetterCodable and PolymorphicCodable property wrappers
+
+Wrapper policy: Polymorphic wrappers follow the same recovery policy as their BetterCodable counterparts. `Optional*` variants treat only `keyNotFound`/`valueWasNil` as nil; `Lossy*` variants recover from all decoding errors. `Optional*` variants differ from their base wrapper only in optionality.
+
+### Macro System
+- Macros are implemented in the `KarrotCodableKitMacros` target
+- Factory classes in `Supports/Factory/` generate syntax nodes
+- `PropertyAnalyzer` and `SyntaxHelper` provide macro development utilities
+
+### PolymorphicEnumCodable Macro
+- **PolymorphicEnumCodableMacro/Decodable/Encodable**: Auto-generates Codable conformance for enums
+- **PolymorphicEnumCodableFactory**: Generates CodingKey and init/encode methods
+- Each case must have exactly one associated value (conforming to `PolymorphicIdentifiable`)
+
+### UnnestedPolymorphic Macros
+Template Method pattern with shared components:
+- **BaseUnnestedPolymorphicMacro**: Protocol extension providing common functionality
+- **UnnestedPolymorphicValidation**: Centralized validation logic with dynamic error messages
+- **PolymorphicMacroArgumentValidator**: Argument extraction and validation
+- **UnnestedPolymorphicCodeGenerator / StructGenerator / MethodGenerator**: Code generation layers
+
+Each macro type (`UnnestedPolymorphicCodableMacro`, `UnnestedPolymorphicDecodableMacro`) implements `UnnestedPolymorphicMacroType` with specific protocol and macro type configurations.
+
+Adding a new UnnestedPolymorphic macro variant:
+1. Implement the `UnnestedPolymorphicMacroType` protocol
+2. Define `protocolType`, `macroType`, and `macroName` properties
+3. Use template methods from the protocol extension for common functionality
+4. Register the macro in `KarrotCodableKitPlugin.swift`
+
+## Code Style
+
+- `.swiftformat` (repo root) is the source of truth: rule whitelist, 2-space indent, 120-column limit. Run `swiftformat .` before committing — it must produce no diff.
+- Multiline string literals (JSON fixtures, expected macro expansions) indent their content and closing `"""` two spaces past the opening line; `--indent-strings true` preserves this — do not "fix" it.
+- `#if DEBUG` blocks add no extra indentation (`--ifdef no-indent`).
+- propertyTypes rule gotchas:
+  - Write `CodingUserInfoKey.resilientDecodingErrorReporter` as `: CodingUserInfoKey = .init(...)!` — the rule miscompiles the multiline `= CodingUserInfoKey(...)!` form into a tuple.
+  - Keep the `// swiftformat:disable propertyTypes` regions around `@DefaultCodable` test doubles — explicit type annotations break the wrapper's generic parameter inference.
+- Code, comments, and documentation are written in English.
+- Follow the Swift API Design Guidelines; prefer dedicated structs/enums over tuples in public API.
+
+## Testing
+
+Test targets:
+- **Tests/KarrotCodableKitTests/**: Runtime functionality tests, organized by feature. Uses **Swift Testing** (`import Testing`, `struct` suites, `@Test`, `#expect`/`#require`).
+- **Tests/KarrotCodableMacrosTests/**: Macro expansion tests. Uses **XCTest** with `assertMacroExpansion` (`SwiftSyntaxMacrosTestSupport` is XCTest-based — do not migrate these to Swift Testing).
+
+Conventions (see existing tests for reference):
+- TDD: write a failing test first (red), then make it pass. Bug fixes start with a regression test reproducing the bug against the old behavior.
+- Test method names are backtick raw identifiers in natural language: ``func `decodes valid JSON`()``.
+- Structure test bodies with `// given` / `// when` / `// then` comments.
+- Use realistic, real-world JSON payloads as fixtures; name test doubles `*Dummy` / `TestDouble*`.
+- Cover edge cases: missing key, null value, type mismatch, empty collections, and encode→decode round-trips.
+- Assert concrete error cases (e.g. specific `DecodingError`), not just "throws".
+- DEBUG-only features (Resilient `outcome`, projected values) get `#if DEBUG`-gated test files (`*ResilientTests.swift`).
+
+## Git & PR Conventions
+
+- Commit subjects: lowercase Conventional Commits — `feat:`, `fix:`, `docs:`, `test:`, `style:`, `refactor:`, `perf:`, `chore:`; optional scope, e.g. `fix(polymorphic):`. Imperative mood.
+- Branch names: `<type>/<slug>`, e.g. `fix/polymorphic-lossy-array-null-outcome`, `docs/update-readme`.
+- PRs are landed with **merge commits** (not squash). Structure work as one logical commit per unit of change — each commit should build and pass tests.
+- Fill in the PR template. Report exact test counts for both configurations in Testing Methods, e.g. "`swift test` passes in debug (303) and release (295), 0 failures".
+- Keep PRs focused: defer unrelated changes (renames, drive-by cleanups) to follow-up PRs.
+- CodeRabbit reviews every PR automatically and applies one of the labels Bug / Feature / Improvement / Update / Docs / Breaking Changes / CI. These labels determine the release-note category (release-drafter) — verify the label matches the change.
+- Reply to review comments in their thread, not as top-level PR comments.
+- CI runs only when `Package.swift`, `Package.resolved`, `Sources/**`, or `Tests/**` change.
+
+## Gotchas
+
+- A type-inference error in the macros module can cascade into unrelated `'@const' value should be initialized with a compile-time value` errors on `@Test` functions. Fix the first real error before trusting the rest of the diagnostics.
+- Release builds strip DEBUG-only API (`outcome` reporting, projected values), so `swift test -c release` runs fewer tests than debug. Always run both.
+- Releases are SemVer git tags without a `v` prefix (e.g. `2.1.0`); pushing a tag drafts release notes from PR labels. Do not create tags or releases unless explicitly asked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to KarrotCodableKit
+
+Thanks for your interest in contributing! Issues and pull requests are welcome.
+
+This guide covers the human workflow. The operational facts (commands,
+architecture, conventions) that both humans and AI coding agents rely on live
+in [AGENTS.md](AGENTS.md) — please skim it before your first change.
+
+English is the default language for code, comments, commits, and docs.
+Issues and PR descriptions in Korean are also welcome.
+
+## Prerequisites
+
+- A Swift 6.2+ toolchain is required to build the test suite (the tests use
+  raw-identifier test names). CI runs macOS 15 with Xcode 26.3.
+- No additional tooling is required; [SwiftFormat](https://github.com/nicklockwood/SwiftFormat)
+  (0.62+) is recommended for formatting.
+
+Getting started:
+
+```bash
+git clone https://github.com/daangn/KarrotCodableKit.git
+cd KarrotCodableKit
+swift build
+open Package.swift   # or open the folder in Xcode
+```
+
+## Building and Testing
+
+```bash
+swift test               # debug configuration
+swift test -c release    # release configuration
+swift test --filter SomeTestClass
+```
+
+A change is done when **both** debug and release test runs pass with zero
+failures. The debug run has more tests than release because DEBUG-only APIs
+(the Resilient `outcome` reporting) have DEBUG-gated tests — that difference
+is expected.
+
+CI runs on pull requests that touch `Package.swift`, `Package.resolved`,
+`Sources/**`, or `Tests/**`: the test matrix (debug/release) plus a macro
+compatibility check across swift-syntax versions.
+
+## Development Workflow
+
+This project follows TDD:
+
+1. Write a failing test that captures the bug or the new behavior.
+2. Make it pass.
+3. Refactor while keeping tests green.
+
+Bug fixes should start with a regression test written against the old
+behavior. Test conventions (Swift Testing vs XCTest, naming, fixtures) are
+described in [AGENTS.md](AGENTS.md#testing).
+
+## Code Style
+
+Formatting is defined by `.swiftformat` in the repo root — run `swiftformat .`
+before committing; it must produce no diff on a clean tree. The basics:
+2-space indent, 120-column limit. There is no lint step in CI; style is
+checked in review.
+
+## Branches, Commits, and Pull Requests
+
+- Branch names: `<type>/<short-slug>`, e.g. `fix/lossy-array-null-outcome`,
+  `feature/optional-polymorphic-value`, `docs/update-readme`.
+- Commit subjects: lowercase [Conventional Commits](https://www.conventionalcommits.org/):
+
+  | Type | Use for | Example |
+  |---|---|---|
+  | `feat` | New functionality | `feat: omit nil optional fields on encode` |
+  | `fix` | Bug fixes | `fix(polymorphic): align lossy array recovery with BetterCodable policy` |
+  | `perf` | Performance | `perf(polymorphic): drop the intermediate Result array` |
+  | `refactor` | No behavior change | `refactor: extract KeyedDecodingContainer extension` |
+  | `test` | Tests only | `test: cover RFC 3339 legacy offset decoding` |
+  | `docs` | Documentation | `docs: correct DefaultEmptyPolymorphicArrayValue docs` |
+  | `style` | Formatting only | `style: apply swiftformat across the codebase` |
+  | `chore` | Tooling, CI, meta | `chore: add issue templates` |
+
+- PRs are merged with a merge commit (not squashed), so structure your branch
+  as one logical commit per unit of change — each commit should build and pass
+  tests on its own.
+- Fill in the PR template, and report exact test counts for both
+  configurations, e.g. "`swift test` passes in debug (303) and release (295),
+  0 failures".
+- Keep PRs focused; put unrelated improvements in a follow-up PR.
+
+## Review Process
+
+- [CodeRabbit](https://coderabbit.ai) reviews every PR automatically and
+  applies a category label (Bug / Feature / Improvement / Update / Docs /
+  Breaking Changes / CI). A maintainer then reviews and merges.
+- Please reply to review comments in their thread (not as top-level PR
+  comments), and feel free to push back with reasoning — review is a
+  conversation.
+
+## Releases
+
+Releases are SemVer git tags without a `v` prefix (e.g. `2.1.0`), created by
+the maintainers. Pushing a tag drafts GitHub release notes grouped by PR
+label, so the label on your PR determines where it appears in the notes.
+
+## Reporting Issues
+
+Please use the issue templates. For bugs, a minimal reproducible code sample
+plus the JSON payload involved makes fixes dramatically faster.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,9 +1,9 @@
-# CLAUDE.md
+# GEMINI.md
 
 @AGENTS.md
 
 AGENTS.md is the canonical source of project instructions for coding agents.
 If your tool does not expand `@` imports, read [AGENTS.md](AGENTS.md) directly.
 
-Add Claude-specific instructions below this line; keep everything
+Add Gemini-specific instructions below this line; keep everything
 project-general in AGENTS.md.


### PR DESCRIPTION
## Background (Required)
- Beyond CLAUDE.md, the PR template, and `.coderabbit.yml`, the repo had no onboarding assets for AI coding agents (Codex, Gemini CLI) or human contributors. This PR sets up a single canonical instruction file plus contributor docs and tooling configs, derived from the conventions observed across the merged PR history.

## Changes
- `.swiftformat` + `.editorconfig`: commit the house-style SwiftFormat configuration (rule whitelist, 2-space indent, 120-column limit) that PR #30 was formatted with. Three rules (`isEmpty`, `wrapIfStatementBodies`, `elseOnSameLine`) are deliberately left out of the whitelist so `swiftformat .` stays idempotent on the existing tree.
- `AGENTS.md`: canonical agent instructions — architecture (moved from CLAUDE.md), commands, code style, testing conventions, git/PR conventions, and gotchas.
- `CLAUDE.md` / `GEMINI.md`: thin pointers importing AGENTS.md via `@AGENTS.md`, so Claude Code, Gemini CLI, and Codex share one source of truth.
- `CONTRIBUTING.md`: human contributor guide — setup, TDD workflow, commit/branch/PR conventions, review flow, releases.
- `.github/ISSUE_TEMPLATE/`: form-based bug report / feature request templates; the auto-applied Bug/Feature labels match the release-drafter categories.
- `.github/pull_request_template.md`: add a Checklist section.
- `.claude/settings.json`: PostToolUse hooks that auto-run swiftformat on edited Swift files. The swiftlint hook is gated on a committed `.swiftlint.yml` (none today), so it stays dormant until one is added.

## Testing Methods
- `swiftformat --lint .` reports 0/185 files requiring formatting — the committed config is idempotent on the current tree.
- `swift test` passes in debug (303) and release (295), 0 failures — run to confirm no behavioral change.
- Issue template YAML syntax validated.
- Docs/config only: CI's path filter (`Package.swift`, `Sources/**`, `Tests/**`) does not trigger on this PR.

## Review Notes
- The `.swiftformat` here is the configuration PR #30 described but did not commit; see the file header for the deliberate deviations that keep the tree untouched.
- Follow-up suggestion (separate PR): `.coderabbit.yml` still says "100 characters per line" while the codebase and `.swiftformat` use 120.
- The `Tests/KarrotCodableMacrosTests/Extenstions` typo fix is split into its own PR to keep this one docs/config-only.

## Checklist
- [x] `swift test -c debug` and `swift test -c release` pass (test counts reported above)
- [ ] Changes are covered by tests (N/A — docs/config only)
- [x] `swiftformat .` produces no diff
- [ ] Docs updated if the public API changed (N/A)

https://claude.ai/code/session_017SJfRUv3HzmLXAAUCKNVah

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution, development, testing, and release guidance.
  * Added guidance for AI-assisted development tools.
  * Documented project formatting and coding conventions.

* **Chores**
  * Added automated Swift formatting and linting support.
  * Standardized repository editor settings.
  * Added structured templates for bug reports, feature requests, and pull requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->